### PR TITLE
feat: subnetwork rework

### DIFF
--- a/src/interfaces/IL1Registry.sol
+++ b/src/interfaces/IL1Registry.sol
@@ -7,11 +7,14 @@ interface IL1Registry {
     event RegisterL1(address indexed validatorManager);
     event SetL1Middleware(address indexed validatorManager, address indexed l1Middleware);
     event SetMetadataURL(address indexed validatorManager, string metadataURL);
+    event RegisterSubnetwork(address indexed validatorManager, uint256 identifier);
 
     error L1Registry__L1AlreadyRegistered();
     error L1Registry__L1NotRegistered();
     error L1Registry__InvalidValidatorManager(address ValidatorManager);
-
+    error L1Registry__SubnetworkAlreadyRegistered(bytes32 subnetwork);
+    error L1Registry__SubnetworkNotRegistered(bytes32 subnetwork);
+    error L1Registry__InvalidSubnetworkIndex(bytes32 subnetwork);
     /**
      * @notice Register an Avalanche L1
      * TODO: verify that the ValidatorManager is effectively the manager of an Avalanche L1 by
@@ -70,4 +73,49 @@ interface IL1Registry {
      * @param metadataURL The new metadata URL
      */
     function setMetadataURL(address validatorManager, string calldata metadataURL) external;
+
+    /**
+     * @notice Register a new subnetwork under a specified parent L1
+     * @param l1 The address of the parent L1
+     * @param identifier The identifier of the subnetwork
+     * @return subnetwork The unique identifier of the subnetwork
+     */
+    function registerSubnetwork(address l1, uint256 identifier) external returns (bytes32 subnetwork);
+
+    /**
+     * @notice Check if a subnetwork is registered under a specified L1
+     * @param subnetwork The unique identifier of the subnetwork
+     * @return True if the subnetwork exists, false otherwise
+     */
+    function isRegisteredSubnetwork(bytes32 subnetwork) external view returns (bool);
+
+    /**
+     * @notice Retrieves the details of a subnetwork by its unique identifier
+     * @param subnetwork The unique identifier of the subnetwork
+     * @return l1 The address of the parent L1
+     * @return identifier The identifier of the subnetwork
+     */
+    function getSubnetwork(bytes32 subnetwork) external view returns (address l1, uint256 identifier);
+
+    /**
+     * @notice Get the unique identifier of a subnetwork by its parent L1 and identifier
+     * @param validatorManager The address of the parent L1
+     * @param identifier The identifier of the subnetwork
+     * @return subnetwork The unique identifier of the subnetwork
+     */
+    function getSubnetworkByParams(address validatorManager, uint256 identifier) external view returns (bytes32 subnetwork);
+
+    /**
+     * @notice Get all subnetworks
+     * @return subnetworks Array of unique identifiers for each subnetwork
+     * @return l1s Array of L1 addresses for each subnetwork
+     * @return identifiers Array of identifiers for each subnetwork
+     */
+    function getAllSubnetworks() external view returns (bytes32[] memory subnetworks, address[] memory l1s, uint256[] memory identifiers);
+
+    /**
+     * @notice Remove a subnetwork by its unique identifier
+     * @param subnetwork The unique identifier of the subnetwork to remove
+     */
+    function removeSubnetwork(bytes32 subnetwork) external;
 }

--- a/test/L1RegistryTest.t.sol
+++ b/test/L1RegistryTest.t.sol
@@ -242,4 +242,106 @@ contract L1RegistryTest is Test {
 
         registry.setMetadataURL(address(mockACP99Manager), newMetadataURL);
     }
+
+    function testRegisterSubnetwork() public {
+        // Registering a new subnetwork for a registered L1 should succeed
+        vm.prank(l1Middleware1);
+        registry.registerL1(address(mockACP99Manager), l1Middleware1SecurityModule, l1Middleware1MetadataURL);
+        bytes32 subnetwork = registry.registerSubnetwork(address(mockACP99Manager), 1);
+        assertEq(registry.isRegisteredSubnetwork(subnetwork), true);
+    }
+
+    function testRegisterSubnetworkRevertNotRegistered() public {
+        // Registering a subnetwork for an unregistered L1 should revert
+        vm.expectRevert(IL1Registry.L1Registry__L1NotRegistered.selector);
+        registry.registerSubnetwork(address(mockACP99Manager), 1);
+    }
+
+    function testRegisterSubnetworkRevertAlreadyRegistered() public {
+        // Registering an already registered subnetwork should revert
+        vm.prank(l1Middleware1);
+        registry.registerL1(address(mockACP99Manager), l1Middleware1SecurityModule, l1Middleware1MetadataURL);
+        bytes32 subnetwork = registry.registerSubnetwork(address(mockACP99Manager), 1);
+        vm.expectRevert(abi.encodeWithSelector(IL1Registry.L1Registry__SubnetworkAlreadyRegistered.selector, subnetwork));
+        registry.registerSubnetwork(address(mockACP99Manager), 1);
+    }
+
+    function testGetSubnetwork() public {
+        // Getting an existing subnetwork's data should succeed
+        vm.prank(l1Middleware1);
+        registry.registerL1(address(mockACP99Manager), l1Middleware1SecurityModule, l1Middleware1MetadataURL);
+        bytes32 subnetwork = registry.registerSubnetwork(address(mockACP99Manager), 1);
+        (address vManager, uint256 id) = registry.getSubnetwork(subnetwork);
+        assertEq(vManager, address(mockACP99Manager));
+        assertEq(id, 1);
+    }
+
+    function testGetSubnetworkRevertNotRegistered() public {
+        // Getting a non-existent subnetwork should revert
+        bytes32 unregistered = keccak256(abi.encodePacked(address(mockACP99Manager), uint256(1)));
+        vm.expectRevert(abi.encodeWithSelector(IL1Registry.L1Registry__SubnetworkNotRegistered.selector, unregistered));
+        registry.getSubnetwork(unregistered);
+    }
+
+    function testGetSubnetworkByParams() public {
+        // Getting a subnetwork by its parameters should succeed if registered
+        vm.prank(l1Middleware1);
+        registry.registerL1(address(mockACP99Manager), l1Middleware1SecurityModule, l1Middleware1MetadataURL);
+        bytes32 subnetwork = registry.registerSubnetwork(address(mockACP99Manager), 2);
+        bytes32 fetched = registry.getSubnetworkByParams(address(mockACP99Manager), 2);
+        assertEq(fetched, subnetwork);
+    }
+
+    function testGetSubnetworkByParamsRevert() public {
+        // Getting a subnetwork by parameters for a non-existent one should revert
+        bytes32 expectedSubnetwork = keccak256(abi.encodePacked(address(mockACP99Manager), uint256(2)));
+        vm.expectRevert(abi.encodeWithSelector(IL1Registry.L1Registry__SubnetworkNotRegistered.selector, expectedSubnetwork));
+        registry.getSubnetworkByParams(address(mockACP99Manager), 2);
+    }
+
+    function testGetAllSubnetworks() public {
+        // Should return all registered subnetworks
+        vm.prank(l1Middleware1);
+        registry.registerL1(address(mockACP99Manager), l1Middleware1SecurityModule, l1Middleware1MetadataURL);
+
+        MockACP99Manager anotherManager = new MockACP99Manager();
+        vm.prank(l1Middleware2);
+        registry.registerL1(address(anotherManager), l1Middleware2SecurityModule, l1Middleware2MetadataURL);
+
+        bytes32 s1 = registry.registerSubnetwork(address(mockACP99Manager), 1);
+        bytes32 s2 = registry.registerSubnetwork(address(anotherManager), 10);
+        bytes32 s3 = registry.registerSubnetwork(address(mockACP99Manager), 2);
+
+        (bytes32[] memory subs, address[] memory managers, uint256[] memory ids) = registry.getAllSubnetworks();
+        assertEq(subs.length, 3);
+        assertEq(managers.length, 3);
+        assertEq(ids.length, 3);
+
+        assertEq(subs[0], s1);
+        assertEq(managers[0], address(mockACP99Manager));
+        assertEq(ids[0], 1);
+
+        assertEq(subs[1], s2);
+        assertEq(managers[1], address(anotherManager));
+        assertEq(ids[1], 10);
+
+        assertEq(subs[2], s3);
+        assertEq(managers[2], address(mockACP99Manager));
+        assertEq(ids[2], 2);
+    }
+
+    function testRemoveSubnetworkRevertWhenRegistered() public {
+        // Trying to remove a subnetwork that is registered should revert
+        vm.prank(l1Middleware1);
+        registry.registerL1(address(mockACP99Manager), l1Middleware1SecurityModule, l1Middleware1MetadataURL);
+        bytes32 subnetwork = registry.registerSubnetwork(address(mockACP99Manager), 1);
+        vm.expectRevert(abi.encodeWithSelector(IL1Registry.L1Registry__SubnetworkAlreadyRegistered.selector, subnetwork));
+        registry.removeSubnetwork(subnetwork);
+    }
+
+    function testRemoveSubnetworkSuccessWhenNotRegistered() public {
+        // Removing an unregistered subnetwork should not revert
+        bytes32 subnetwork = keccak256(abi.encodePacked(address(mockACP99Manager), uint256(1)));
+        registry.removeSubnetwork(subnetwork);
+    }
 }

--- a/test/vault/vaultTokenizedTest.t.sol
+++ b/test/vault/vaultTokenizedTest.t.sol
@@ -2870,13 +2870,13 @@ contract VaultTokenizedTest is Test {
     //     return (VaultTokenized(vault_), FullRestakeDelegator(delegator_), Slasher(slasher_));
     // }
 
-    function _registerOperator(
-        address user
-    ) internal {
-        vm.startPrank(user);
-        operatorRegistry.registerOperator();
-        vm.stopPrank();
-    }
+    // function _registerOperator(
+    //     address user
+    // ) internal {
+    //     vm.startPrank(user);
+    //     operatorRegistry.registerOperator();
+    //     vm.stopPrank();
+    // }
 
     // function _registerL1(address user, address middleware) internal {
     //     vm.startPrank(user);


### PR DESCRIPTION
### Linked issues

- None

### Dependencies

- None

### Changes

- L1Registry
  - Introduce registration of subnetworks directly in `L1Registry` instead of using the `Subnetwork` library.
  - Add `registerSubnetwork`, `isRegisteredSubnetwork`, `getSubnetwork`, `getSubnetworkByParams`, and `getAllSubnetworks` functions.
  - Maintain a mapping and set of subnetworks (using `bytes32` keys) for registration.
  - Emit `RegisterSubnetwork` event when a subnetwork is registered.

- Tests
  - Update and add tests for the new subnetwork functions in `L1Registry`.

### Breaking changes

- Removed use of `Subnetwork` library. Existing code relying on `Subnetwork` library calls within `L1Registry` must now be updated to use the new `L1Registry` subnetwork registration functions.
- `Subnetworks` are now registered

### Additional comments

- **Anyone can register a subnetwork in a L1**. We should think if this should only be available for the `ValidatorManager` or the Curator. We could simply add an address check, or use Roles. 
- `Subnetwork` could change it's name due to `networks` not existing in Suzaku atm, and it might bring confusing with Avalanche Subnets.
