### PR TITLE
fix: vaultManager deployment

### DIFF
--- a/script/middleware/DeployAvalancheL1Middleware.s.sol
+++ b/script/middleware/DeployAvalancheL1Middleware.s.sol
@@ -79,8 +79,10 @@ contract DeployTestAvalancheL1Middleware is Script {
         MiddlewareVaultManager vaultManager =
             new MiddlewareVaultManager(address(vaultFactory), validatorManagerAddress, validatorManagerAddress);
 
-        avalancheL1Middleware.setVaultManager(address(vaultManager));
+        vm.stopBroadcast();
 
+        vm.startBroadcast(protocolOwnerKey);
+        avalancheL1Middleware.setVaultManager(address(vaultManager));
         vm.stopBroadcast();
 
         return address(avalancheL1Middleware);


### PR DESCRIPTION
### Linked issues

<!-- List of issues this PR fixes. E.g.

- Fixes #12
- Fixes #14

-->

### Dependencies

<!-- List of PR that need to be merged before this PR. E.g.

- https://github.com/AshAvalanche/ash-infra/pull/26
- https://github.com/AshAvalanche/ansible-avalanche-collection/pull/32

If empty, please remove the section title -->

### Changes

<!-- List of changes brought by the PR. Proposed format: "- Scope\n  - Description". E.g.

- SDK
  - Add 4 networks with [Ankr](https://www.ankr.com/) and [Blast](https://blastapi.io/) endpoints to `conf/default.yml` (e.g. `fuji-ankr`). Both services provide decentralized public RPC endpoints. This allows going around Ava Labs' public RPC rate limiting which is very low.
- CI
  - Add a GitHub Actions workflow to run tests on PRs

-->

### Breaking changes

<!-- List of breaking changes brought by the PR. Proposed format: "- _(scope)_ Description". E.g.

- _(node role)_ `avalanche_tracked_subnets` has been renamed to `avalanchego_track_subnets`

-->

### Additional comments

<!-- You can for example ask for feedback here or link to new issues deriving from the PR.
If empty, please remove the section title -->
