### PR TITLE
fix: issue #148

### DIFF
--- a/test/mocks/MockVault.sol
+++ b/test/mocks/MockVault.sol
@@ -6,6 +6,8 @@ interface IVaultTokenized {
     function collateral() external view returns (address);
     function delegator() external view returns (address);
     function activeBalanceOfAt(address, uint48, bytes calldata) external view returns (uint256);
+    function activeSharesOfAt(address, uint48, bytes calldata) external view returns (uint256);
+    function activeSharesAt(uint48, bytes calldata) external view returns (uint256);
     function owner() external view returns (address);
 }
 
@@ -14,6 +16,7 @@ contract MockVault is IVaultTokenized {
     address private _delegator;
     address private _owner;
     mapping(address => uint256) public activeBalance;
+    mapping(uint48 => uint256) private _totalActiveShares;
 
     constructor(address collateralAddress, address delegatorAddress, address owner_) {
         _collateral = collateralAddress;
@@ -29,7 +32,7 @@ contract MockVault is IVaultTokenized {
         return _delegator;
     }
 
-    function activeBalanceOfAt(address account, uint48, bytes calldata) public view returns (uint256) {
+    function activeBalanceOfAt(address account, uint48, bytes calldata) public view override returns (uint256) {
         return activeBalance[account];
     }
 
@@ -41,7 +44,16 @@ contract MockVault is IVaultTokenized {
         return _owner;
     }
 
-    function activeSharesOfAt(address account, uint48, bytes calldata) public view returns (uint256) {
+    function activeSharesOfAt(address account, uint48, bytes calldata) public view override returns (uint256) {
         return 100;
+    }
+
+    function activeSharesAt(uint48 timestamp, bytes calldata) public view override returns (uint256) {
+        uint256 totalShares = _totalActiveShares[timestamp];
+        return totalShares > 0 ? totalShares : 200; // Default to 200 if not explicitly set
+    }
+
+    function setTotalActiveShares(uint48 timestamp, uint256 totalShares) public {
+        _totalActiveShares[timestamp] = totalShares;
     }
 }

--- a/test/rewards/RewardsTest.t.sol
+++ b/test/rewards/RewardsTest.t.sol
@@ -530,6 +530,10 @@ contract RewardsTest is Test {
         // Set staker balance in vault
         address vault = vaultManager.vaults(0);
         MockVault(vault).setActiveBalance(staker, 300_000 * 1e18);
+        
+        // Set total active shares
+        uint256 epochTs = middleware.getEpochStartTs(epoch);
+        MockVault(vault).setTotalActiveShares(uint48(epochTs), 400_000 * 1e18);
 
         // Distribute rewards
         test_distributeRewards(4 hours);
@@ -566,6 +570,11 @@ contract RewardsTest is Test {
         // Setup staker balance and distribute rewards
         address vault = vaultManager.vaults(0);
         MockVault(vault).setActiveBalance(staker, 300_000 * 1e18);
+        
+        // Set total active shares for the epoch timestamp
+        uint256 epochTs = middleware.getEpochStartTs(epoch);
+        MockVault(vault).setTotalActiveShares(uint48(epochTs), 400_000 * 1e18);
+        
         vm.prank(REWARDS_DISTRIBUTOR_ROLE);
         test_distributeRewards(4 hours);
 
@@ -595,6 +604,11 @@ contract RewardsTest is Test {
         uint48 epoch = 1;
         address staker = makeAddr("Staker");
 
+        // Set up total shares but no staker balance
+        address vault = vaultManager.vaults(0);
+        uint256 epochTs = middleware.getEpochStartTs(epoch);
+        MockVault(vault).setTotalActiveShares(uint48(epochTs), 400_000 * 1e18);
+
         // Distribute rewards but don't give staker any stake
         test_distributeRewards(4 hours);
 
@@ -613,6 +627,10 @@ contract RewardsTest is Test {
         // Give staker balance but don't distribute rewards
         address vault = vaultManager.vaults(0);
         MockVault(vault).setActiveBalance(staker, 300_000 * 1e18);
+        
+        // Set total active shares
+        uint256 epochTs = middleware.getEpochStartTs(epoch);
+        MockVault(vault).setTotalActiveShares(uint48(epochTs), 400_000 * 1e18);
 
         // Warp to next epoch
         vm.warp((epoch + 1) * middleware.EPOCH_DURATION());


### PR DESCRIPTION
### Linked issues

<!-- List of issues this PR fixes. E.g.

- Fixes #12
- Fixes #14

-->

### Dependencies

<!-- List of PR that need to be merged before this PR. E.g.

- https://github.com/AshAvalanche/ash-infra/pull/26
- https://github.com/AshAvalanche/ansible-avalanche-collection/pull/32

If empty, please remove the section title -->

### Changes

<!-- List of changes brought by the PR. Proposed format: "- Scope\n  - Description". E.g.

- SDK
  - Add 4 networks with [Ankr](https://www.ankr.com/) and [Blast](https://blastapi.io/) endpoints to `conf/default.yml` (e.g. `fuji-ankr`). Both services provide decentralized public RPC endpoints. This allows going around Ava Labs' public RPC rate limiting which is very low.
- CI
  - Add a GitHub Actions workflow to run tests on PRs

-->

### Breaking changes

<!-- List of breaking changes brought by the PR. Proposed format: "- _(scope)_ Description". E.g.

- _(node role)_ `avalanche_tracked_subnets` has been renamed to `avalanchego_track_subnets`

-->

### Additional comments

<!-- You can for example ask for feedback here or link to new issues deriving from the PR.
If empty, please remove the section title -->
