### PR TITLE
Permissionless complete

### DIFF
--- a/script/middleware/MiddlewareL1.s.sol
+++ b/script/middleware/MiddlewareL1.s.sol
@@ -12,7 +12,7 @@ import {MiddlewareConfig} from "./MiddlewareL1Types.s.sol";
 
 /**
  * @dev Deploy only AvalancheL1Middleware + MiddlewareVaultManager.
- * @dev All other addresses (validatorManager, operatorRegistry, vaultFactory, operatorL1OptIn) must be passed in from JSON.
+ * @dev All other addresses (balancer, operatorRegistry, vaultFactory, operatorL1OptIn) must be passed in from JSON.
  */
 contract DeployTestAvalancheL1Middleware is Script {
     function executeMiddlewareL1Deployment(
@@ -23,7 +23,7 @@ contract DeployTestAvalancheL1Middleware is Script {
         // Deploy the AvalancheL1Middleware
         AvalancheL1Middleware middleware = new AvalancheL1Middleware(
             AvalancheL1MiddlewareSettings({
-                l1ValidatorManager: middlewareConfig.validatorManager,
+                balancer: middlewareConfig.balancer,
                 operatorRegistry: middlewareConfig.operatorRegistry,
                 vaultRegistry: middlewareConfig.vaultFactory,
                 operatorL1Optin: middlewareConfig.operatorL1OptIn,
@@ -57,7 +57,7 @@ contract DeployTestAvalancheL1Middleware is Script {
 
         console2.log("AvalancheL1Middleware deployed at:", middlewareL1);
         console2.log("MiddlewareVaultManager deployed at:", vaultManager);
-        console2.log("Using validatorManager at:", middlewareConfig.validatorManager);
+        console2.log("Using balancer at:", middlewareConfig.balancer);
         console2.log("Using operatorRegistry at:", middlewareConfig.operatorRegistry);
         console2.log("Using vaultFactory at:", middlewareConfig.vaultFactory);
         console2.log("Using operatorL1OptIn at:", middlewareConfig.operatorL1OptIn);

--- a/script/middleware/MiddlewareL1Types.s.sol
+++ b/script/middleware/MiddlewareL1Types.s.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.25;
 
 struct MiddlewareConfig {
     address middlewareOwnerAddress;
-    address validatorManager;
+    address balancer;
     address operatorRegistry;
     address vaultFactory;
     address operatorL1OptIn;

--- a/script/middleware/anvil/DeployAvalancheL1Middleware.s.sol
+++ b/script/middleware/anvil/DeployAvalancheL1Middleware.s.sol
@@ -42,6 +42,8 @@ contract DeployTestAvalancheL1Middleware is Script {
         address proxyAdminOwnerAddress = vm.addr(proxyAdminOwnerKey);
         address protocolOwnerAddress = vm.addr(protocolOwnerKey);
 
+        // Deploy the ValidatorManager stack (Balancer, SecurityModule, ValidatorManager)
+        // The Balancer will be owned by protocolOwnerAddress
         DeployBalancerValidatorManager deployScript = new DeployBalancerValidatorManager();
         
         (address balancerAddress, address securityModule, address validatorManagerAddress) = deployScript.run(
@@ -60,9 +62,11 @@ contract DeployTestAvalancheL1Middleware is Script {
         OperatorL1OptInService operatorL1OptIn =
             new OperatorL1OptInService(address(operatorRegistry), address(l1Registry), "Suzaku Operator -> L1 Opt-In");
 
+        // Deploy the AvalancheL1Middleware with protocolOwnerAddress as owner
+        // The middleware will NOT be transferred to the balancer - it stays owned by EOA
         AvalancheL1Middleware avalancheL1Middleware = new AvalancheL1Middleware(
             AvalancheL1MiddlewareSettings({
-                l1ValidatorManager: balancerAddress,
+                balancer: balancerAddress,
                 operatorRegistry: address(operatorRegistry),
                 vaultRegistry: address(vaultFactory),
                 operatorL1Optin: address(operatorL1OptIn),
@@ -78,7 +82,7 @@ contract DeployTestAvalancheL1Middleware is Script {
         );
 
         MiddlewareVaultManager vaultManager =
-            new MiddlewareVaultManager(address(vaultFactory), validatorManagerAddress, validatorManagerAddress, 24); // 24 epoch delay
+            new MiddlewareVaultManager(address(vaultFactory), protocolOwnerAddress, address(avalancheL1Middleware), 24); // 24 epoch delay
 
         vm.startBroadcast(protocolOwnerKey);
         avalancheL1Middleware.setVaultManager(address(vaultManager));

--- a/src/contracts/L1Registry.sol
+++ b/src/contracts/L1Registry.sol
@@ -35,10 +35,10 @@ contract L1Registry is IL1Registry, Ownable {
     modifier onlyValidatorManagerOwner(
         address l1
     ) {
-        // Ensure caller owns the validator manager
-        address vmOwner = Ownable(l1).owner();
-        if (vmOwner != msg.sender) {
-            revert L1Registry__NotValidatorManagerOwner(msg.sender, vmOwner);
+        // Ensure caller owns the balancer (which itself owns the validator manager)
+        address balancerOwner = Ownable(l1).owner();
+        if (balancerOwner != msg.sender) {
+            revert L1Registry__NotValidatorManagerOwner(msg.sender, balancerOwner);
         }
         _;
     }
@@ -71,6 +71,10 @@ contract L1Registry is IL1Registry, Ownable {
     }
 
     /// @inheritdoc IL1Registry
+    /// @notice Register an L1 (balancer) with its associated middleware and metadata
+    /// @param l1 The balancer address
+    /// @param middleware_ The middleware address for this L1
+    /// @param metadataURL The metadata URL for this L1
     function registerL1(
         address l1,
         address middleware_,
@@ -108,6 +112,9 @@ contract L1Registry is IL1Registry, Ownable {
     }
 
     /// @inheritdoc IL1Registry
+    /// @notice Update the middleware for a registered L1
+    /// @param l1 The balancer address (not the raw validator manager)
+    /// @param middleware_ The new middleware address
     function setL1Middleware(
         address l1,
         address middleware_
@@ -118,6 +125,9 @@ contract L1Registry is IL1Registry, Ownable {
     }
 
     /// @inheritdoc IL1Registry
+    /// @notice Update the metadata URL for a registered L1
+    /// @param l1 The balancer address (not the raw validator manager)
+    /// @param metadataURL The new metadata URL
     function setMetadataURL(
         address l1,
         string calldata metadataURL

--- a/src/contracts/L1Registry.sol
+++ b/src/contracts/L1Registry.sol
@@ -76,12 +76,13 @@ contract L1Registry is IL1Registry, Ownable {
         address middleware_,
         string calldata metadataURL
     ) external payable notZeroAddress(l1) onlyValidatorManagerOwner(l1) {
-        if (registerFee == 0) {
+        uint256 fee = registerFee;
+        if (fee == 0) {
             if (msg.value > 0) revert L1Registry__UnexpectedEther();
         } else {
-            if (msg.value < registerFee) revert L1Registry__InsufficientFee();
+            if (msg.value < fee) revert L1Registry__InsufficientFee();
 
-            uint256 excess = msg.value - registerFee;
+            uint256 excess = msg.value - fee;
 
             // refund excess first – ensures balance is available
             if (excess > 0) {
@@ -90,8 +91,8 @@ contract L1Registry is IL1Registry, Ownable {
             }
 
             // forward exact fee
-            (bool success, ) = feeCollector.call{value: registerFee}("");
-            if (!success) unclaimedFees += registerFee;
+            (bool success, ) = feeCollector.call{value: fee}("");
+            if (!success) unclaimedFees += fee;
         }
 
         bool registered = l1s.add(l1);

--- a/src/contracts/middleware/AvalancheL1Middleware.sol
+++ b/src/contracts/middleware/AvalancheL1Middleware.sol
@@ -594,34 +594,60 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
         _initializeValidatorStakeUpdate(msg.sender, validationID, stakeAmount);
     }
 
-    /**
-     * @inheritdoc IAvalancheL1Middleware
-     */
-    function completeValidatorRegistration(
-        address operator,
-        bytes32 nodeId,
-        uint32 messageIndex
-    ) external {
-        _updateGlobalNodeStakeOncePerEpoch();
-        _completeValidatorRegistration(operator, nodeId, messageIndex);
-    }
 
-    /**
-     * @inheritdoc IAvalancheL1Middleware
-     */
-    function completeStakeUpdate(
-        bytes32 nodeId,
-        uint32 messageIndex
-    ) external {
-        _updateGlobalNodeStakeOncePerEpoch();
-        _completeStakeUpdate(msg.sender, nodeId, messageIndex);
-    }
 
     function completeValidatorRemoval(
         uint32 messageIndex
     ) external {
         _updateGlobalNodeStakeOncePerEpoch();
         _completeValidatorRemoval(messageIndex);
+    }
+
+    // --- Permissionless completes (messageIndex-only) ---
+
+    function completeValidatorRegistration(uint32 messageIndex) external {
+        _updateGlobalNodeStakeOncePerEpoch();
+
+        bytes32 vid = balancerValidatorManager.completeValidatorRegistration(messageIndex);
+
+        // Only act for validators owned by this module
+        if (balancerValidatorManager.getValidatorSecurityModule(vid) != address(this)) {
+            return;
+        }
+        // No local cache change needed on registration; stake was staged in addNode().
+    }
+
+    function completeStakeUpdate(uint32 messageIndex) external {
+        _updateGlobalNodeStakeOncePerEpoch();
+
+        (bytes32 vid, /*nonce*/) = balancerValidatorManager.completeValidatorWeightUpdate(messageIndex);
+
+        // Only act for validators owned by this module
+        if (balancerValidatorManager.getValidatorSecurityModule(vid) != address(this)) {
+            return;
+        }
+
+        address operator = validationIdToOperator[vid];
+        if (operator == address(0)) return; // not ours / unknown locally
+
+        uint48 currentEpoch = getCurrentEpoch();
+        uint256 newStake = _pendingStake[vid];
+
+        // Cache next-epoch stake if still active and not pending removal
+        Validator memory v = balancerValidatorManager.getValidator(vid);
+        if (newStake != 0 && v.status == ValidatorStatus.Active && !nodePendingRemoval[vid]) {
+            nodeStakeCache[currentEpoch + 1][vid] = newStake;
+        }
+
+        // Unlock delta on increases
+        uint256 prevStake = getEffectiveNodeStake(currentEpoch, vid);
+        if (newStake > prevStake) {
+            uint256 release = newStake - prevStake;
+            uint256 lockBal = operatorLockedStake[operator];
+            operatorLockedStake[operator] = (release > lockBal) ? 0 : (lockBal - release);
+        }
+
+        delete _pendingStake[vid];
     }
 
     /**
@@ -844,20 +870,7 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
         }
     }
 
-    /**
-     * @notice Completes a validator's registration.
-     * @param operator The operator who owns the validator
-     * @param nodeId The unique ID of the validator whose registration is being finalized
-     * @param messageIndex The message index from the BalancerValidatorManager (used for ordering/verification)
-     */
-    function _completeValidatorRegistration(
-        address operator,
-        bytes32 nodeId,
-        uint32 messageIndex
-    ) internal {
-        _onlyRegisteredOperatorNode(operator, nodeId);
-        balancerValidatorManager.completeValidatorRegistration(messageIndex);
-    }
+
 
     /**
      * @notice Completes a validator's removal.
@@ -869,49 +882,7 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
         balancerValidatorManager.completeValidatorRemoval(messageIndex);
     }
 
-    /**
-     * @notice Completes a validator's stake update
-     * @param operator The operator who owns the validator
-     * @param nodeId The unique ID of the validator whose relative weight update is being finalized
-     * @param messageIndex The message index from the BalancerValidatorManager (used for ordering/verification)
-     */
-    function _completeStakeUpdate(
-        address operator,
-        bytes32 nodeId,
-        uint32 messageIndex
-    ) internal {
-        _onlyRegisteredOperatorNode(operator, nodeId);
-        bytes32 validationID = balancerValidatorManager.getNodeValidationID(abi.encodePacked(uint160(uint256(nodeId))));
 
-        if (!balancerValidatorManager.isValidatorPendingWeightUpdate(validationID)) {
-            revert AvalancheL1Middleware__WeightUpdateNotPending(validationID);
-        }
-
-        // Finish the weight update on the P-Chain
-        (bytes32 vid, ) = balancerValidatorManager.completeValidatorWeightUpdate(messageIndex);
-        if (vid != validationID) {
-            revert AvalancheL1Middleware__UnexpectedWeightUpdate(validationID);
-        }
-
-
-        uint48 currentEpoch = getCurrentEpoch();
-        uint256 newStake = _pendingStake[validationID];
-
-        // write to cache active validators
-        Validator memory v = balancerValidatorManager.getValidator(validationID);
-        if (v.status == ValidatorStatus.Active && !nodePendingRemoval[validationID]) {
-            nodeStakeCache[currentEpoch + 1][validationID] = newStake;
-        }
-
-        // unlock stake
-        uint256 prevStake = getEffectiveNodeStake(currentEpoch, validationID);
-        if (newStake > prevStake) {
-            uint256 release = newStake - prevStake;
-            uint256 lockBal = operatorLockedStake[operator];
-            operatorLockedStake[operator] = (release > lockBal) ? 0 : lockBal - release;
-        }
-        delete _pendingStake[validationID];
-    }
 
     /**
      * @notice Sets the stake of a validator and updates the operator's locked stake accordingly.

--- a/src/contracts/middleware/AvalancheL1Middleware.sol
+++ b/src/contracts/middleware/AvalancheL1Middleware.sol
@@ -1049,6 +1049,8 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
         uint48 epochStartTs = getEpochStartTs(epoch);
 
         uint256 totalVaults = vaultManager.getVaultCount();
+        // use the class' canonical unit (decimals) for normalization
+        uint8 classDec = collateralClasses[collateralClassId].unitDecimals;
 
         for (uint256 i; i < totalVaults;) {
             (address vault, uint48 enabledTime, uint48 disabledTime) = vaultManager.getVaultAtWithTimes(i);
@@ -1072,10 +1074,11 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
             address collateral = IVaultTokenized(vault).collateral();
             uint8 dec = IERC20Metadata(collateral).decimals();
 
-            if (dec < 18) {
-                vaultStake *= 10 ** uint256(18 - dec);
-            } else if (dec > 18) {
-                vaultStake /= 10 ** uint256(dec - 18);
+            // normalize per-vault stake into the class unit
+            if (dec < classDec) {
+                vaultStake *= 10 ** uint256(classDec - dec);
+            } else if (dec > classDec) {
+                vaultStake /= 10 ** uint256(dec - classDec);
             }
 
             stake += vaultStake;

--- a/src/contracts/middleware/AvalancheL1Middleware.sol
+++ b/src/contracts/middleware/AvalancheL1Middleware.sol
@@ -222,6 +222,8 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
         emit VaultManagerUpdated(address(vaultManager), vaultManager_);
     }
 
+
+
     /**
      * @inheritdoc IAvalancheL1Middleware
      */
@@ -598,7 +600,7 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
         uint32 messageIndex
     ) external {
         _updateGlobalNodeStakeOncePerEpoch();
-        _completeValidatorRemoval(messageIndex);
+        balancerValidatorManager.completeValidatorRemoval(messageIndex);
     }
 
     /**
@@ -606,14 +608,7 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
      */
     function completeValidatorRegistration(uint32 messageIndex) external {
         _updateGlobalNodeStakeOncePerEpoch();
-
-        bytes32 vid = balancerValidatorManager.completeValidatorRegistration(messageIndex);
-
-        // Only act for validators owned by this module
-        if (balancerValidatorManager.getValidatorSecurityModule(vid) != address(this)) {
-            return;
-        }
-        // No local cache change needed on registration; stake was staged in addNode().
+        balancerValidatorManager.completeValidatorRegistration(messageIndex);
     }
 
     /**
@@ -624,9 +619,10 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
 
         (bytes32 vid, /*nonce*/) = balancerValidatorManager.completeValidatorWeightUpdate(messageIndex);
 
-        // Only act for validators owned by this module
-        if (balancerValidatorManager.getValidatorSecurityModule(vid) != address(this)) {
-            return;
+        // Enforce ownership. If not from this module, revert so the middleware's update rolls back.
+        address owner = balancerValidatorManager.getValidatorSecurityModule(vid);
+        if (owner != address(this)) {
+            revert AvalancheL1Middleware__MessageNotForThisModule(vid, owner);
         }
 
         address operator = validationIdToOperator[vid];
@@ -873,16 +869,6 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
     }
 
     /**
-     * @notice Completes a validator's removal.
-     * @param messageIndex The message index from the BalancerValidatorManager (used for ordering/verification)
-     */
-    function _completeValidatorRemoval(
-        uint32 messageIndex
-    ) internal {
-        balancerValidatorManager.completeValidatorRemoval(messageIndex);
-    }
-
-    /**
      * @notice Sets the stake of a validator and updates the operator's locked stake accordingly.
      * @param operator The operator who owns the validator
      * @param validationID The unique ID of the validator whose stake is being updated
@@ -1101,6 +1087,8 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
         return operatorNodesArray[operator].length;
     }
 
+
+
     /**
      * @inheritdoc IAvalancheL1Middleware
      */
@@ -1178,6 +1166,8 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
     function getVaultManager() external view returns (address) {
         return address(vaultManager);
     }
+
+
 
     /**
      * @inheritdoc IAvalancheL1Middleware

--- a/src/contracts/middleware/AvalancheL1Middleware.sol
+++ b/src/contracts/middleware/AvalancheL1Middleware.sol
@@ -222,8 +222,6 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
         emit VaultManagerUpdated(address(vaultManager), vaultManager_);
     }
 
-
-
     /**
      * @inheritdoc IAvalancheL1Middleware
      */
@@ -874,8 +872,6 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
         }
     }
 
-
-
     /**
      * @notice Completes a validator's removal.
      * @param messageIndex The message index from the BalancerValidatorManager (used for ordering/verification)
@@ -885,8 +881,6 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
     ) internal {
         balancerValidatorManager.completeValidatorRemoval(messageIndex);
     }
-
-
 
     /**
      * @notice Sets the stake of a validator and updates the operator's locked stake accordingly.
@@ -1107,8 +1101,6 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
         return operatorNodesArray[operator].length;
     }
 
-
-
     /**
      * @inheritdoc IAvalancheL1Middleware
      */
@@ -1186,8 +1178,6 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
     function getVaultManager() external view returns (address) {
         return address(vaultManager);
     }
-
-
 
     /**
      * @inheritdoc IAvalancheL1Middleware

--- a/src/contracts/middleware/AvalancheL1Middleware.sol
+++ b/src/contracts/middleware/AvalancheL1Middleware.sol
@@ -593,8 +593,9 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
         _initializeValidatorStakeUpdate(msg.sender, validationID, stakeAmount);
     }
 
-
-
+    /**
+     * @inheritdoc IAvalancheL1Middleware
+     */
     function completeValidatorRemoval(
         uint32 messageIndex
     ) external {
@@ -602,8 +603,9 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
         _completeValidatorRemoval(messageIndex);
     }
 
-    // --- Permissionless completes (messageIndex-only) ---
-
+    /**
+     * @inheritdoc IAvalancheL1Middleware
+     */
     function completeValidatorRegistration(uint32 messageIndex) external {
         _updateGlobalNodeStakeOncePerEpoch();
 
@@ -616,6 +618,9 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
         // No local cache change needed on registration; stake was staged in addNode().
     }
 
+    /**
+     * @inheritdoc IAvalancheL1Middleware
+     */
     function completeStakeUpdate(uint32 messageIndex) external {
         _updateGlobalNodeStakeOncePerEpoch();
 

--- a/src/contracts/middleware/AvalancheL1Middleware.sol
+++ b/src/contracts/middleware/AvalancheL1Middleware.sol
@@ -28,7 +28,7 @@ import {StakeConversion} from "./libraries/StakeConversion.sol";
 import {BaseDelegator} from "../../contracts/delegator/BaseDelegator.sol";
 
 struct AvalancheL1MiddlewareSettings {
-    address l1ValidatorManager;
+    address balancer;
     address operatorRegistry;
     address vaultRegistry;
     address operatorL1Optin;
@@ -48,7 +48,7 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
     using EnumerableMap for EnumerableMap.Bytes32ToUintMap;
     using EnumerableSet for EnumerableSet.Bytes32Set;
 
-    address public immutable L1_VALIDATOR_MANAGER;
+    address public immutable BALANCER;
     address public immutable OPERATOR_REGISTRY;
     address public immutable OPERATOR_L1_OPTIN;
     address public immutable PRIMARY_ASSET;
@@ -106,7 +106,7 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
         uint256 primaryCollateralMinStake,
         uint256 primaryCollateralWeightScaleFactor
     ) CollateralClassRegistry(owner) {
-        if (settings.l1ValidatorManager == address(0)) {
+        if (settings.balancer == address(0)) {
             revert AvalancheL1Middleware__ZeroAddress();
         }
         if (settings.operatorRegistry == address(0)) {
@@ -154,7 +154,7 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
 
         START_TIME = Time.timestamp();
         EPOCH_DURATION = settings.epochDuration;
-        L1_VALIDATOR_MANAGER = settings.l1ValidatorManager;
+        BALANCER = settings.balancer;
         OPERATOR_REGISTRY = settings.operatorRegistry;
         OPERATOR_L1_OPTIN = settings.operatorL1Optin;
         SLASHING_WINDOW = settings.slashingWindow;
@@ -162,7 +162,7 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
         UPDATE_WINDOW = settings.stakeUpdateWindow;
         WEIGHT_SCALE_FACTOR = primaryCollateralWeightScaleFactor;
 
-        balancerValidatorManager = IBalancerValidatorManager(settings.l1ValidatorManager);
+        balancerValidatorManager = IBalancerValidatorManager(settings.balancer);
         _addCollateralClass(PRIMARY_ASSET_CLASS, primaryCollateralMinStake, primaryCollateralMaxStake, PRIMARY_ASSET);
     }
 
@@ -308,8 +308,8 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
         if (!IOperatorRegistry(OPERATOR_REGISTRY).isRegistered(operator)) {
             revert AvalancheL1Middleware__OperatorNotRegistered(operator);
         }
-        if (!IOptInService(OPERATOR_L1_OPTIN).isOptedIn(operator, L1_VALIDATOR_MANAGER)) {
-            revert AvalancheL1Middleware__OperatorNotOptedIn(operator, L1_VALIDATOR_MANAGER);
+        if (!IOptInService(OPERATOR_L1_OPTIN).isOptedIn(operator, BALANCER)) {
+            revert AvalancheL1Middleware__OperatorNotOptedIn(operator, BALANCER);
         }
 
         operators.add(operator);
@@ -1066,7 +1066,7 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
             }
 
             uint256 vaultStake = BaseDelegator(IVaultTokenized(vault).delegator()).stakeAt(
-                L1_VALIDATOR_MANAGER, collateralClassId, operator, epochStartTs, new bytes(0)
+                BALANCER, collateralClassId, operator, epochStartTs, new bytes(0)
             );
 
             address collateral = IVaultTokenized(vault).collateral();

--- a/src/contracts/middleware/AvalancheL1Middleware.sol
+++ b/src/contracts/middleware/AvalancheL1Middleware.sol
@@ -378,7 +378,7 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
             revert AvalancheL1Middleware__InsufficientStake();
         }
 
-        bytes32 valId = balancerValidatorManager.getNodeValidationID(abi.encodePacked(uint160(uint256(nodeId))));
+        bytes32 valId = _vid(nodeId);
         if (nodePendingRemoval[valId]) revert AvalancheL1Middleware__NodePending();
         if (balancerValidatorManager.isValidatorPendingWeightUpdate(valId)) revert AvalancheL1Middleware__NodePending();
 
@@ -399,7 +399,7 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
         }
 
         bytes32 validationID = balancerValidatorManager.initiateValidatorRegistration(
-            abi.encodePacked(uint160(uint256(nodeId))),
+            _nodeKey(nodeId),
             blsKey,
             remainingBalanceOwner,
             disableOwner,
@@ -434,10 +434,10 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
     )
         external
     {
-        _updateStakeCache(getCurrentEpoch(), PRIMARY_ASSET_CLASS);
+        uint48 currentEpoch = getCurrentEpoch();
+        _updateStakeCache(currentEpoch, PRIMARY_ASSET_CLASS);
         _onlyDuringFinalWindowOfEpoch();
         _updateGlobalNodeStakeOncePerEpoch();
-        uint48 currentEpoch = getCurrentEpoch();
         if (rebalancedThisEpoch[operator][currentEpoch]) {
             revert AvalancheL1Middleware__RebalanceNotRequired();
         }
@@ -446,8 +446,7 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
             revert AvalancheL1Middleware__OperatorNotRegistered(operator);
         }
 
-        uint48 epoch = getCurrentEpoch();
-        uint256 newTotalStake = getOperatorStake(operator, epoch, PRIMARY_ASSET_CLASS);
+        uint256 newTotalStake = getOperatorStake(operator, currentEpoch, PRIMARY_ASSET_CLASS);
         
         // Enforce max security module weight cap
         (, uint64 securityModuleMaxWeight) = balancerValidatorManager.getSecurityModuleWeights(address(this));
@@ -494,7 +493,7 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
         for (uint256 i = length; i > 0 && (leftoverStake > 0 || !secondaryOk);) {
             i--;
             bytes32 nodeId = nodesArr[i];
-            bytes32 valID = balancerValidatorManager.getNodeValidationID(abi.encodePacked(uint160(uint256(nodeId))));
+            bytes32 valID = _vid(nodeId);
             if (balancerValidatorManager.isValidatorPendingWeightUpdate(valID)) {
                 continue;
             }
@@ -579,7 +578,7 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
             revert AvalancheL1Middleware__InvalidStakeAmount();
         }
 
-        bytes32 validationID = balancerValidatorManager.getNodeValidationID(abi.encodePacked(uint160(uint256(nodeId))));
+        bytes32 validationID = _vid(nodeId);
         
         // Check if operator has enough available stake for the increase
         uint48 currentEpoch = getCurrentEpoch();
@@ -658,7 +657,7 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
         address, /* operator */
         uint256, /* amount */
         uint96 collateralClassId
-    ) public onlyOwner {
+    ) external onlyOwner {
         _updateStakeCache(epoch, collateralClassId);
         _updateGlobalNodeStakeOncePerEpoch();
         revert AvalancheL1Middleware__NotImplemented();
@@ -796,7 +795,7 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
         for (uint256 i = nodeArray.length; i > 0;) {
             i--;
             bytes32 nodeId = nodeArray[i];
-            bytes32 valID = balancerValidatorManager.getNodeValidationID(abi.encodePacked(uint160(uint256(nodeId))));
+            bytes32 valID = _vid(nodeId);
             // validator already deleted on manager → use local cache
             if (valID == bytes32(0)) {
                 bytes32 saved = pendingRemovalValId[nodeId];
@@ -831,7 +830,7 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
      * @param nodeId The node ID
      */
     function _removeNode(address operator, bytes32 nodeId) internal {
-        bytes32 validationID = balancerValidatorManager.getNodeValidationID(abi.encodePacked(uint160(uint256(nodeId))));
+        bytes32 validationID = _vid(nodeId);
         if (balancerValidatorManager.isValidatorPendingWeightUpdate(validationID)) {
             revert AvalancheL1Middleware__NodePending();
         }
@@ -946,9 +945,7 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
     function _getActiveNodeCount(address operator) internal view returns (uint256 count) {
         bytes32[] storage arr = operatorNodesArray[operator];
         for (uint256 i; i < arr.length;) {
-            bytes32 valID = balancerValidatorManager.getNodeValidationID(
-                abi.encodePacked(uint160(uint256(arr[i])))
-            );
+            bytes32 valID = _vid(arr[i]);
             if (!nodePendingRemoval[valID]) {
                 unchecked { ++count; }
             }
@@ -1147,8 +1144,7 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
 
         for (uint256 i = 0; i < allNodeIds.length; i++) {
             bytes32 nodeId = allNodeIds[i];
-            bytes32 validationID =
-                balancerValidatorManager.getNodeValidationID(abi.encodePacked(uint160(uint256(nodeId))));
+            bytes32 validationID = _vid(nodeId);
             Validator memory validator = balancerValidatorManager.getValidator(validationID);
 
             // Skip if no validator is registered for this nodeId
@@ -1194,8 +1190,7 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
         bytes32[] storage nodesArr = operatorNodesArray[operator];
         for (uint256 i = 0; i < nodesArr.length;) {
             bytes32 nodeId = nodesArr[i];
-            bytes32 validationID =
-                balancerValidatorManager.getNodeValidationID(abi.encodePacked(uint160(uint256(nodeId))));
+            bytes32 validationID = _vid(nodeId);
             registeredStake += getEffectiveNodeStake(getCurrentEpoch(), validationID);
             unchecked { ++i; }
         }
@@ -1224,8 +1219,7 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
 
             for (uint256 i = 0; i < nodesArr.length; i++) {
                 bytes32 nodeId = nodesArr[i];
-                bytes32 validationID =
-                    balancerValidatorManager.getNodeValidationID(abi.encodePacked(uint160(uint256(nodeId))));
+                bytes32 validationID = _vid(nodeId);
                 operatorStake += getEffectiveNodeStake(epoch, validationID);
             }
             return operatorStake;
@@ -1310,5 +1304,13 @@ contract AvalancheL1Middleware is IAvalancheL1Middleware, CollateralClassRegistr
      */
     function _wasActiveAt(uint48 enabledTime, uint48 disabledTime, uint48 timestamp) private pure returns (bool) {
         return enabledTime != 0 && enabledTime <= timestamp && (disabledTime == 0 || disabledTime > timestamp);
+    }
+
+    function _nodeKey(bytes32 nodeId) private pure returns (bytes memory) {
+        return abi.encodePacked(uint160(uint256(nodeId)));
+    }
+
+    function _vid(bytes32 nodeId) private view returns (bytes32) {
+        return balancerValidatorManager.getNodeValidationID(_nodeKey(nodeId));
     }
 }

--- a/src/contracts/middleware/CollateralClassRegistry.sol
+++ b/src/contracts/middleware/CollateralClassRegistry.sol
@@ -4,6 +4,7 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import {ICollateralClassRegistry} from "../../interfaces/middleware/ICollateralClassRegistry.sol";
 
@@ -15,6 +16,7 @@ abstract contract CollateralClassRegistry is ICollateralClassRegistry, Ownable {
         EnumerableSet.AddressSet assets;
         uint256 minValidatorStake;
         uint256 maxValidatorStake;
+        uint8   unitDecimals;
     }
 
     EnumerableSet.UintSet internal collateralClassIds;
@@ -100,6 +102,7 @@ abstract contract CollateralClassRegistry is ICollateralClassRegistry, Ownable {
         CollateralClass storage cls = collateralClasses[collateralClassId];
         cls.minValidatorStake = minValidatorStake;
         cls.maxValidatorStake = maxValidatorStake;
+        cls.unitDecimals = IERC20Metadata(initialAsset).decimals();
 
         emit CollateralClassAdded(collateralClassId, minValidatorStake, maxValidatorStake);
 

--- a/src/contracts/middleware/CollateralClassRegistry.sol
+++ b/src/contracts/middleware/CollateralClassRegistry.sol
@@ -111,6 +111,14 @@ abstract contract CollateralClassRegistry is ICollateralClassRegistry, Ownable {
 
     function _addAssetToClass(uint256 collateralClassId, address asset) internal {
         CollateralClass storage cls = collateralClasses[collateralClassId];
+        // All assets in a class must share the same decimals
+        uint8 dec = IERC20Metadata(asset).decimals();
+        if (cls.assets.length() == 0) {
+            // safety: first asset defines the unit (already set in _addCollateralClass)
+            cls.unitDecimals = dec;
+        } else if (dec != cls.unitDecimals) {
+            revert CollateralClassRegistry__AssetDecimalsMismatch(cls.unitDecimals, dec);
+        }
 
         bool added = cls.assets.add(asset);
         if (!added) {

--- a/src/contracts/middleware/MiddlewareVaultManager.sol
+++ b/src/contracts/middleware/MiddlewareVaultManager.sol
@@ -162,7 +162,7 @@ contract MiddlewareVaultManager is IMiddlewareVaultManager, Ownable {
             );
         }
         address delegator = IVaultTokenized(vault).delegator();
-        BaseDelegator(delegator).setMaxL1Limit(middleware.L1_VALIDATOR_MANAGER(), collateralClassId, amount);
+        BaseDelegator(delegator).setMaxL1Limit(middleware.BALANCER(), collateralClassId, amount);
     }
 
     function slashVault() external pure {

--- a/src/contracts/rewards/Rewards.sol
+++ b/src/contracts/rewards/Rewards.sol
@@ -653,7 +653,7 @@ contract Rewards is AccessControlUpgradeable, ReentrancyGuardUpgradeable, IRewar
             if (operatorCollateralClassShare == 0) continue;
 
             uint256 vaultStake = BaseDelegator(IVaultTokenized(vault).delegator()).stakeAt(
-                middleware.L1_VALIDATOR_MANAGER(), vaultCollateralClass, operator, epochTs, new bytes(0)
+                middleware.BALANCER(), vaultCollateralClass, operator, epochTs, new bytes(0)
             );
 
             if (vaultStake > 0) {

--- a/src/contracts/rewards/UptimeTracker.sol
+++ b/src/contracts/rewards/UptimeTracker.sol
@@ -47,7 +47,7 @@ contract UptimeTracker is IUptimeTracker {
     ) {
         middleware = AvalancheL1Middleware(middleware_);
         epochDuration = middleware.EPOCH_DURATION();
-        validatorManager = BalancerValidatorManager(middleware.L1_VALIDATOR_MANAGER());
+        validatorManager = BalancerValidatorManager(middleware.BALANCER());
         uptimeBlockchainID = uptimeBlockchainID_;
     }
 

--- a/src/interfaces/IL1Registry.sol
+++ b/src/interfaces/IL1Registry.sol
@@ -24,10 +24,10 @@ interface IL1Registry {
 
     /**
      * @notice Register an Avalanche L1
-     * @dev l1 must be the manager of the Avalanche L1
+     * @dev l1 must be the balancer of the Avalanche L1
      * @dev msg.sender must be a SecurityModule of the l1
      * @dev middleware must be a SecurityModule of the Avalanche L1
-     * @param l1 The Avalanche L1. Should be The ValidatorManager.
+     * @param l1 The Avalanche L1. Should be The Balancer.
      * @param middleware The middleware of the Avalanche L1
      * @param metadataURL The metadata URL of the Avalanche L1
      */
@@ -42,7 +42,7 @@ interface IL1Registry {
 
     /**
      * @notice Check if an address is registered as an L1
-     * @param l1 The Avalanche L1. Should be The ValidatorManager.
+     * @param l1 The Avalanche L1. Should be the Balancer.
      * @return True if the address is registered as an L1, false otherwise
      */
     function isRegistered(
@@ -51,7 +51,7 @@ interface IL1Registry {
 
     /**
      * @notice Check if an address is registered as an L1 and if the Middleware is correct
-     * @param l1 The Avalanche L1. Should be The ValidatorManager.
+     * @param l1 The Avalanche L1. Should be the Balancer.
      * @param l1middleware_ The middleware to check
      * @return True if the address is registered as an L1 and the middleware is correct, false otherwise
      */
@@ -84,14 +84,14 @@ interface IL1Registry {
 
     /**
      * @notice Set the middleware of an L1
-     * @param l1 The Avalanche L1. Should be The ValidatorManager.
+     * @param l1 The Avalanche L1. Should be the Balancer.
      * @param middleware_ The new middleware
      */
     function setL1Middleware(address l1, address middleware_) external;
 
     /**
      * @notice Set the metadata URL of an L1
-     * @param l1 The Avalanche L1. Should be The ValidatorManager.
+     * @param l1 The Avalanche L1. Should be the Balancer.
      * @param metadataURL The new metadata URL
      */
     function setMetadataURL(address l1, string calldata metadataURL) external;

--- a/src/interfaces/middleware/IAvalancheL1Middleware.sol
+++ b/src/interfaces/middleware/IAvalancheL1Middleware.sol
@@ -40,6 +40,7 @@ interface IAvalancheL1Middleware {
     error AvalancheL1Middleware__VaultManagerAlreadySet(address vaultManager);
     error AvalancheL1Middleware__OperatorHasActiveNodes(address operator, uint256 nodeCount);
     error AvalancheL1Middleware__UnexpectedWeightUpdate(bytes32 validationID);
+    error AvalancheL1Middleware__MessageNotForThisModule(bytes32 validationID, address ownerModule);
     // Events
     /**
      * @notice Emitted when a node is added

--- a/src/interfaces/middleware/IAvalancheL1Middleware.sol
+++ b/src/interfaces/middleware/IAvalancheL1Middleware.sol
@@ -195,19 +195,16 @@ interface IAvalancheL1Middleware {
     function initializeValidatorStakeUpdate(bytes32 nodeId, uint256 stakeAmount) external;
 
     /**
-     * @notice Finalize a pending validator registration
-     * @param operator The operator address
-     * @param nodeId The node ID
+     * @notice Finalize a pending validator registration (permissionless)
      * @param messageIndex The message index
      */
-    function completeValidatorRegistration(address operator, bytes32 nodeId, uint32 messageIndex) external;
+    function completeValidatorRegistration(uint32 messageIndex) external;
 
     /**
-     * @notice Finalize a pending stake update
-     * @param nodeId The node ID
+     * @notice Finalize a pending stake update (permissionless)
      * @param messageIndex The message index
      */
-    function completeStakeUpdate(bytes32 nodeId, uint32 messageIndex) external;
+    function completeStakeUpdate(uint32 messageIndex) external;
 
     /**
      * @notice Finalize a pending validator removal

--- a/src/interfaces/middleware/ICollateralClassRegistry.sol
+++ b/src/interfaces/middleware/ICollateralClassRegistry.sol
@@ -12,6 +12,7 @@ interface ICollateralClassRegistry {
     error CollateralClassRegistry__AssetIsPrimaryCollateralClass(uint256 collateralClassId);
     error CollateralClassRegistry__AssetsStillExist();
     error CollateralClassRegistry__InvalidStakingRequirements();
+    error CollateralClassRegistry__AssetDecimalsMismatch(uint8 expected, uint8 actual);
 
     event CollateralClassAdded(uint256 indexed collateralClassId, uint256 primaryCollateralMinStake, uint256 primaryCollateralMaxStake);
     event AssetAdded(uint256 indexed collateralClassId, address indexed asset);

--- a/test/delegator/TestL1RestakeDelegator.t.sol
+++ b/test/delegator/TestL1RestakeDelegator.t.sol
@@ -127,7 +127,7 @@ contract L1RestakeDelegatorTest is Test {
         );
 
         AvalancheL1MiddlewareSettings memory middlewareSettings = AvalancheL1MiddlewareSettings({
-            l1ValidatorManager: address(validatorManagerAddress),
+            balancer: address(validatorManagerAddress),
             operatorRegistry: address(operatorRegistry),
             vaultRegistry: address(vaultFactory),
             operatorL1Optin: address(operatorL1OptInService),

--- a/test/middleware/AvalancheL1MiddlewareTest.t.sol
+++ b/test/middleware/AvalancheL1MiddlewareTest.t.sol
@@ -2409,8 +2409,8 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
     function test_operatorStakeWithoutNormalization() public {
         uint48 epoch = 1;
         // Deploy tokens with different decimals
-        ERC20WithDecimals tokenA1 = new ERC20WithDecimals("TokenA", "TKA", 6); // e.g., USDC
-        ERC20WithDecimals tokenB1 = new ERC20WithDecimals("TokenB", "TKB", 18); // e.g., DAI
+        ERC20WithDecimals tokenA1 = new ERC20WithDecimals("TokenA", "TKA", 6);
+        ERC20WithDecimals tokenB1 = new ERC20WithDecimals("TokenB", "TKB", 6);
 
         // Deploy vaults and associate with asset class 1
         vm.startPrank(protocolOwner);
@@ -2537,14 +2537,14 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         //_optInOperatorL1(alice, balancer);
 
         _setL1Limit(curatorOwner2, balancer, 2, 10000 * 10**6, _delegator2);
-        _setL1Limit(curatorOwner3, balancer, 2, 10 * 10**18, _delegator3);
+        _setL1Limit(curatorOwner3, balancer, 2, 10 * 10**6, _delegator3);
 
         // Define stakes without normalization
-        uint256 stakeA = 10000 * 10**6; // 10,000 TokenA (6 decimals)
-        uint256 stakeB = 10 * 10**18; // 10 TokenB (18 decimals)
+        uint256 stakeA = 10000 * 10**6; // 10,000 (6 decimals)
+        uint256 stakeB = 10 * 10**6;    // 10 (6 decimals)
 
-        // class canonical unit is 6 decimals (initial asset is 6d), so normalize 18d -> 6d
-        uint256 normalised = stakeA + stakeB / 10**12; 
+        // same unit (6d) → direct sum
+        uint256 normalised = stakeA + stakeB; 
 
         tokenA1.transfer(staker, stakeA);
         vm.startPrank(staker);
@@ -2561,7 +2561,8 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         vm.warp((epoch + 3) * middleware.EPOCH_DURATION());
 
         assertEq(middleware.getOperatorStake(alice, 2, 2), normalised);
-        assertNotEq(middleware.getOperatorStake(alice, 2, 2), stakeA + stakeB);
+        // With same decimals (6), no normalization occurs, so they're equal
+        assertEq(middleware.getOperatorStake(alice, 2, 2), stakeA + stakeB);
     }
 
         function test_vaultManager_UpdateVaultMaxL1Limit_NoRevert() public {

--- a/test/middleware/AvalancheL1MiddlewareTest.t.sol
+++ b/test/middleware/AvalancheL1MiddlewareTest.t.sol
@@ -2543,7 +2543,8 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         uint256 stakeA = 10000 * 10**6; // 10,000 TokenA (6 decimals)
         uint256 stakeB = 10 * 10**18; // 10 TokenB (18 decimals)
 
-        uint256 normalised = stakeA * 10**12 + stakeB; 
+        // class canonical unit is 6 decimals (initial asset is 6d), so normalize 18d -> 6d
+        uint256 normalised = stakeA + stakeB / 10**12; 
 
         tokenA1.transfer(staker, stakeA);
         vm.startPrank(staker);

--- a/test/middleware/AvalancheL1MiddlewareTest.t.sol
+++ b/test/middleware/AvalancheL1MiddlewareTest.t.sol
@@ -117,12 +117,12 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         (uint256 deposited, uint256 minted) = _deposit(staker, depositAmount);
 
         // Set L1 limit
-        vm.startPrank(bob);
-        delegator.setL1Limit(validatorManagerAddress, collateralClassId, deposited);
+        vm.startPrank(curatorOwner1);
+        delegator.setL1Limit(balancer, collateralClassId, deposited);
         vm.stopPrank();
 
         // Assign the actual minted shares to the operator
-        _setOperatorL1Shares(bob, validatorManagerAddress, collateralClassId, alice, minted, delegator);
+        _setOperatorL1Shares(curatorOwner1, balancer, collateralClassId, alice, minted, delegator);
 
         // travel to next epoch
         _calcAndWarpOneEpoch();
@@ -169,10 +169,10 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         // 1) Setup a small balance so an over-ask is guaranteed
         uint256 depositAmount = 20 ether;
         (uint256 deposited, uint256 minted) = _deposit(staker, depositAmount);
-        vm.startPrank(bob);
-        delegator.setL1Limit(validatorManagerAddress, collateralClassId, deposited);
+        vm.startPrank(curatorOwner1);
+        delegator.setL1Limit(balancer, collateralClassId, deposited);
         vm.stopPrank();
-        _setOperatorL1Shares(bob, validatorManagerAddress, collateralClassId, alice, minted, delegator);
+        _setOperatorL1Shares(curatorOwner1, balancer, collateralClassId, alice, minted, delegator);
         _calcAndWarpOneEpoch();
 
         uint256 avail = middleware.getOperatorAvailableStake(alice);
@@ -231,7 +231,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
 
     function test_CompleteStakeUpdate() public {
         (depositedAmount, mintedShares) = _deposit(staker, 10 ether);
-        _setL1Limit(bob, validatorManagerAddress, 1, depositedAmount, delegator);
+        _setL1Limit(curatorOwner1, balancer, 1, depositedAmount, delegator);
 
         _calcAndWarpOneEpoch();
         (bytes32[] memory nodeIds, bytes32[] memory validationIDs, uint256[] memory nodeWeights) =
@@ -271,7 +271,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
 
     function test_CompleteLateNodeWeightUpdate() public {
         (depositedAmount, mintedShares) = _deposit(staker, 10 ether);
-        _setL1Limit(bob, validatorManagerAddress, 1, depositedAmount, delegator);
+        _setL1Limit(curatorOwner1, balancer, 1, depositedAmount, delegator);
 
         uint48 epoch = _calcAndWarpOneEpoch();
         (bytes32[] memory nodeIds, bytes32[] memory validationIDs, uint256[] memory nodeWeights) =
@@ -543,7 +543,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         console2.log("Making additional deposit:", extraDeposit);
         (uint256 newDeposit, uint256 newShares) = _deposit(staker, extraDeposit);
         uint256 totalShares = mintedShares + newShares;
-        _setOperatorL1Shares(bob, validatorManagerAddress, collateralClassId, alice, totalShares, delegator);
+        _setOperatorL1Shares(curatorOwner1, balancer, collateralClassId, alice, totalShares, delegator);
         console2.log("Additional deposit made. Amount:", newDeposit, "Shares:", newShares);
 
         epoch = _moveToNextEpochAndCalc(3);
@@ -945,8 +945,8 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         // Operator deposit (50-100 ETH)
         uint256 depositAmount = bound(uint256(seedNodeCount) * 10, 50 ether, 100 ether);
         (uint256 depositUsed, uint256 mintedShares_) = _deposit(staker, depositAmount);
-        _setL1Limit(bob, validatorManagerAddress, collateralClassId, depositUsed, delegator);
-        _setOperatorL1Shares(bob, validatorManagerAddress, collateralClassId, alice, mintedShares_, delegator);
+        _setL1Limit(curatorOwner1, balancer, collateralClassId, depositUsed, delegator);
+        _setOperatorL1Shares(curatorOwner1, balancer, collateralClassId, alice, mintedShares_, delegator);
 
         // BLS key and owners
         bytes memory blsKey = new bytes(48);
@@ -1143,7 +1143,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         (uint256 depositUsedA, uint256 mintedSharesA) = vault.deposit(staker, depositAmountA);
         vm.stopPrank();
 
-        _setOperatorL1Shares(bob, validatorManagerAddress, collateralClassId, alice, mintedSharesA, delegator);
+        _setOperatorL1Shares(curatorOwner1, balancer, collateralClassId, alice, mintedSharesA, delegator);
 
         uint256 depositAmountB = bound(uint256(seedNodeCountB) * 10, 50 ether, 100 ether);
         // Use staker to deposit for Charlie
@@ -1153,8 +1153,8 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         (uint256 depositUsedB, uint256 mintedSharesB) = vault.deposit(staker, depositAmountB);
         vm.stopPrank();
 
-        _setL1Limit(bob, validatorManagerAddress, collateralClassId, depositUsedA + depositUsedB, delegator);
-        _setOperatorL1Shares(bob, validatorManagerAddress, collateralClassId, charlie, mintedSharesB, delegator);
+        _setL1Limit(curatorOwner1, balancer, collateralClassId, depositUsedA + depositUsedB, delegator);
+        _setOperatorL1Shares(curatorOwner1, balancer, collateralClassId, charlie, mintedSharesB, delegator);
         _calcAndWarpOneEpoch();
 
         // Create nodes for operator A (Alice)
@@ -1372,10 +1372,10 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         // Dave Operator for vault3 has 100_000_000_000_000 deposited
         // Dave Operator for vault2 has 160_000_000_000_000 deposited
 
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vaultManager.registerVault(address(vault2), 1, 3000 ether);
         vm.stopPrank();
-        _setL1Limit(bob, validatorManagerAddress, 1, 2500 ether, delegator2);
+        _setL1Limit(curatorOwner2, balancer, 1, 2500 ether, delegator2);
 
         // Add collateral2 to collateralClassId = 2
         _setupCollateralClassAndRegisterVault(2, 1, collateral2, vault3, 3000 ether, 2500 ether, delegator3);
@@ -1441,10 +1441,10 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         // Dave Operator for vault3 has 100_000_000_000_000 deposited
         // Dave Operator for vault2 has 160_000_000_000_000 deposited
 
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vaultManager.registerVault(address(vault2), 1, 3000 ether);
         vm.stopPrank();
-        _setL1Limit(bob, validatorManagerAddress, 1, 2500 ether, delegator2);
+        _setL1Limit(curatorOwner2, balancer, 1, 2500 ether, delegator2);
 
         // Add collateral2 to collateralClassId = 2
         _setupCollateralClassAndRegisterVault(2, 1, collateral2, vault3, 3000 ether, 2500 ether, delegator3);
@@ -1701,7 +1701,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
     }
 
     function test_ManualUpdateProcessesEpochsIncrementallyAndAutoUpdateSucceedsAfterCatchUp() public {
-        address middlewareOwner = validatorManagerAddress;
+        address middlewareOwner = balancer;
 
         uint48 maxAutoUpdates = middleware.MAX_AUTO_EPOCH_UPDATES();
         uint48 totalEpochsToMakePending = maxAutoUpdates + 2;
@@ -1791,8 +1791,8 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         uint256 initialDeposit = 1000 ether;
         (uint256 depositAmount, uint256 initialShares) = _deposit(delegatedStaker, initialDeposit);
 
-        _setL1Limit(bob, validatorManagerAddress, collateralClassId, depositAmount, delegator);
-        _setOperatorL1Shares(bob, validatorManagerAddress, collateralClassId, alice, initialShares, delegator);
+        _setL1Limit(curatorOwner1, balancer, collateralClassId, depositAmount, delegator);
+        _setOperatorL1Shares(curatorOwner1, balancer, collateralClassId, alice, initialShares, delegator);
 
         _calcAndWarpOneEpoch();
         (, bytes32[] memory validationIDs,) = _createAndConfirmNodes(alice, 2, 0, true, 1);
@@ -1816,7 +1816,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         vm.stopPrank();        
 
         uint256 newOperatorShares = initialShares - burnedShares;
-        _setOperatorL1Shares(bob, validatorManagerAddress, collateralClassId, alice, newOperatorShares, delegator);
+        _setOperatorL1Shares(curatorOwner1, balancer, collateralClassId, alice, newOperatorShares, delegator);
         
         uint48 epoch3 = _calcAndWarpOneEpoch();
         middleware.calcAndCacheNodeStakeForAllOperators();
@@ -1969,7 +1969,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         collateral.approve(address(vault), stakeAmountOpA);
         (,uint256 sharesA) = vault.deposit(operatorA, stakeAmountOpA);
         vm.stopPrank();
-        _setOperatorL1Shares(bob, validatorManagerAddress, collateralClassId, operatorA, sharesA, delegator);
+        _setOperatorL1Shares(curatorOwner1, balancer, collateralClassId, operatorA, sharesA, delegator);
 
         // Operator B deposits and sets shares
         collateral.transfer(staker, stakeAmountOpB);
@@ -1977,7 +1977,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         collateral.approve(address(vault), stakeAmountOpB);
         (,uint256 sharesB) = vault.deposit(operatorB, stakeAmountOpB);
         vm.stopPrank();
-        _setOperatorL1Shares(bob, validatorManagerAddress, collateralClassId, operatorB, sharesB, delegator);
+        _setOperatorL1Shares(curatorOwner1, balancer, collateralClassId, operatorB, sharesB, delegator);
         
         _calcAndWarpOneEpoch(); // Ensure stakes are recognized
 
@@ -2121,9 +2121,9 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         console2.log("Operator stake (epoch", epoch, "):", operatorStake);
         assertGt(operatorStake, 0);
 
-        MiddlewareVaultManager vaultManager2 = new MiddlewareVaultManager(address(vaultFactory), owner, address(middleware), 24); // 24 epoch delay
+        MiddlewareVaultManager vaultManager2 = new MiddlewareVaultManager(address(vaultFactory), l1Owner, address(middleware), 24); // 24 epoch delay
 
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vm.expectRevert(abi.encodeWithSelector(IAvalancheL1Middleware.AvalancheL1Middleware__VaultManagerAlreadySet.selector, address(vaultManager)));
         middleware.setVaultManager(address(vaultManager2));
         vm.stopPrank();
@@ -2146,7 +2146,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         assertGt(aliceStake, 0, "Alice should have stake");
         
         // Try to disable the operator with active nodes - should REVERT
-        vm.prank(validatorManagerAddress);
+        vm.prank(l1Owner);
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAvalancheL1Middleware.AvalancheL1Middleware__OperatorHasActiveNodes.selector,
@@ -2174,7 +2174,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         assertEq(remainingNodes, 0, "Alice should have no active nodes after removal processing");
         
         // Now disable should work
-        vm.prank(validatorManagerAddress);
+        vm.prank(l1Owner);
         middleware.disableOperator(alice);
         
         // Warp past the window to allow removal
@@ -2182,7 +2182,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         _moveToNextEpochAndCalc(removalDelay);
         
         // Now removal should work since operator has no active nodes
-        vm.prank(validatorManagerAddress);
+        vm.prank(l1Owner);
         middleware.removeOperator(alice);
         
         // Verify alice is removed from operators mapping
@@ -2218,14 +2218,14 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         uint256 minSecondaryStakePerNodeForClass2 = 5 ether;
 
         // Setup the secondary collateral class
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         middleware.addCollateralClass(secondaryCollateralClassId, minSecondaryStakePerNodeForClass2, 0, address(collateral2));
         middleware.activateSecondaryCollateralClass(secondaryCollateralClassId);
         vaultManager.registerVault(address(vault3), secondaryCollateralClassId, 3000 ether);
         vm.stopPrank();
         
         // Set L1 limit for the secondary collateral class
-        _setL1Limit(bob, validatorManagerAddress, secondaryCollateralClassId, 2500 ether, delegator3);
+        _setL1Limit(curatorOwner3, balancer, secondaryCollateralClassId, 2500 ether, delegator3);
 
         // --- Alice gets and deposits secondary stake into vault3 ---
         // IMPORTANT: Deposit enough for ALL 3 nodes (15 ETH) since primary will be insufficient
@@ -2243,7 +2243,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         vm.stopPrank();
 
         // 4. Assign these minted shares to Alice for the L1 system
-        _setOperatorL1Shares(bob, validatorManagerAddress, secondaryCollateralClassId, alice, mintedSecondarySharesAlice, delegator3);
+        _setOperatorL1Shares(curatorOwner3, balancer, secondaryCollateralClassId, alice, mintedSecondarySharesAlice, delegator3);
 
         // Make sure changes are reflected
         currentEpoch = _calcAndWarpOneEpoch();
@@ -2300,7 +2300,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
 
         // Update Alice's operator shares to reflect the withdrawal
         uint256 remainingSecondaryShares = mintedSecondarySharesAlice - (mintedSecondarySharesAlice * secondaryToWithdraw / aliceTargetSecondaryStake);
-        _setOperatorL1Shares(bob, validatorManagerAddress, secondaryCollateralClassId, alice, remainingSecondaryShares, delegator3);
+        _setOperatorL1Shares(curatorOwner3, balancer, secondaryCollateralClassId, alice, remainingSecondaryShares, delegator3);
 
         currentEpoch = _calcAndWarpOneEpoch();
         middleware.calcAndCacheStakes(currentEpoch, secondaryCollateralClassId);
@@ -2342,8 +2342,8 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         
         // Now allocate more of this deposited stake to Alice (the operator)
         uint256 totalAliceShares = mintedShares + additionalMinted;
-        _setL1Limit(bob, validatorManagerAddress, collateralClassId, 3000 ether, delegator);
-        _setOperatorL1Shares(bob, validatorManagerAddress, collateralClassId, alice, totalAliceShares, delegator);
+        _setL1Limit(curatorOwner1, balancer, collateralClassId, 3000 ether, delegator);
+        _setOperatorL1Shares(curatorOwner1, balancer, collateralClassId, alice, totalAliceShares, delegator);
 
         // Move to next epoch to make the new stake available
         epoch = _calcAndWarpOneEpoch();
@@ -2413,10 +2413,10 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         ERC20WithDecimals tokenB1 = new ERC20WithDecimals("TokenB", "TKB", 18); // e.g., DAI
 
         // Deploy vaults and associate with asset class 1
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(protocolOwner);
         address vaultAddress1 = vaultFactory.create(
             1,
-            bob,
+            curatorOwner2,
             abi.encode(
                 IVaultTokenized.InitParams({
                     collateral: address(tokenA1),
@@ -2425,11 +2425,11 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
                     depositWhitelist: false,
                     isDepositLimit: false,
                     depositLimit: 0,
-                    defaultAdminRoleHolder: bob,
-                    depositWhitelistSetRoleHolder: bob,
-                    depositorWhitelistRoleHolder: bob,
-                    isDepositLimitSetRoleHolder: bob,
-                    depositLimitSetRoleHolder: bob,
+                    defaultAdminRoleHolder: curatorOwner2,
+                    depositWhitelistSetRoleHolder: curatorOwner2,
+                    depositorWhitelistRoleHolder: curatorOwner2,
+                    isDepositLimitSetRoleHolder: curatorOwner2,
+                    depositLimitSetRoleHolder: curatorOwner2,
                     name: "Test",
                     symbol: "TEST"
                 })
@@ -2439,7 +2439,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         );
         address vaultAddress2 = vaultFactory.create(
             1,
-            bob,
+            curatorOwner3,
             abi.encode(
                 IVaultTokenized.InitParams({
                     collateral: address(tokenB1),
@@ -2448,11 +2448,11 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
                     depositWhitelist: false,
                     isDepositLimit: false,
                     depositLimit: 0,
-                    defaultAdminRoleHolder: bob,
-                    depositWhitelistSetRoleHolder: bob,
-                    depositorWhitelistRoleHolder: bob,
-                    isDepositLimitSetRoleHolder: bob,
-                    depositLimitSetRoleHolder: bob,
+                    defaultAdminRoleHolder: curatorOwner3,
+                    depositWhitelistSetRoleHolder: curatorOwner3,
+                    depositorWhitelistRoleHolder: curatorOwner3,
+                    isDepositLimitSetRoleHolder: curatorOwner3,
+                    depositLimitSetRoleHolder: curatorOwner3,
                     name: "Test",
                     symbol: "TEST"
                 })
@@ -2462,16 +2462,16 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         );
         VaultTokenized vaultTokenA = VaultTokenized(vaultAddress1);
         VaultTokenized vaultTokenB = VaultTokenized(vaultAddress2);
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         middleware.addCollateralClass(2, 0, 100, address(tokenA1));
         middleware.activateSecondaryCollateralClass(2);
         middleware.addAssetToClass(2, address(tokenB1));
         vm.stopPrank();
 
         address[] memory l1LimitSetRoleHolders = new address[](1);
-        l1LimitSetRoleHolders[0] = bob;
+        l1LimitSetRoleHolders[0] = curatorOwner2;
         address[] memory operatorL1SharesSetRoleHolders = new address[](1);
-        operatorL1SharesSetRoleHolders[0] = bob;
+        operatorL1SharesSetRoleHolders[0] = curatorOwner2;
 
         address delegatorAddress2 = delegatorFactory.create(
             0,
@@ -2480,9 +2480,9 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
                 abi.encode(
                     IL1RestakeDelegator.InitParams({
                         baseParams: IBaseDelegator.BaseParams({
-                            defaultAdminRoleHolder: bob,
+                            defaultAdminRoleHolder: curatorOwner2,
                             hook: address(0),
-                            hookSetRoleHolder: bob
+                            hookSetRoleHolder: curatorOwner2
                         }),
                         l1LimitSetRoleHolders: l1LimitSetRoleHolders,
                         operatorL1SharesSetRoleHolders: operatorL1SharesSetRoleHolders
@@ -2492,6 +2492,12 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         );
         L1RestakeDelegator _delegator2 = L1RestakeDelegator(delegatorAddress2);
 
+        // Create separate role holders for delegator3
+        address[] memory l1LimitSetRoleHolders3 = new address[](1);
+        l1LimitSetRoleHolders3[0] = curatorOwner3;
+        address[] memory operatorL1SharesSetRoleHolders3 = new address[](1);
+        operatorL1SharesSetRoleHolders3[0] = curatorOwner3;
+        
         address delegatorAddress3 = delegatorFactory.create(
             0,
             abi.encode(
@@ -2499,39 +2505,39 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
                 abi.encode(
                     IL1RestakeDelegator.InitParams({
                         baseParams: IBaseDelegator.BaseParams({
-                            defaultAdminRoleHolder: bob,
+                            defaultAdminRoleHolder: curatorOwner3,
                             hook: address(0),
-                            hookSetRoleHolder: bob
+                            hookSetRoleHolder: curatorOwner3
                         }),
-                        l1LimitSetRoleHolders: l1LimitSetRoleHolders,
-                        operatorL1SharesSetRoleHolders: operatorL1SharesSetRoleHolders
+                        l1LimitSetRoleHolders: l1LimitSetRoleHolders3,
+                        operatorL1SharesSetRoleHolders: operatorL1SharesSetRoleHolders3
                     })
                 )
             )
         );
         L1RestakeDelegator _delegator3 = L1RestakeDelegator(delegatorAddress3);
 
-        vm.prank(bob);
+        vm.prank(curatorOwner2);
         vaultTokenA.setDelegator(delegatorAddress2);
 
         // Set the delegator in vault3
-        vm.prank(bob);
+        vm.prank(curatorOwner3);
         vaultTokenB.setDelegator(delegatorAddress3);
 
-        _setOperatorL1Shares(bob, validatorManagerAddress, 2, alice, 100, _delegator2);
-        _setOperatorL1Shares(bob, validatorManagerAddress, 2, alice, 100, _delegator3);
+        _setOperatorL1Shares(curatorOwner2, balancer, 2, alice, 100, _delegator2);
+        _setOperatorL1Shares(curatorOwner3, balancer, 2, alice, 100, _delegator3);
 
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vaultManager.registerVault(address(vaultTokenA), 2, 3000 ether);
         vaultManager.registerVault(address(vaultTokenB), 2, 3000 ether);
         vm.stopPrank();
 
         _optInOperatorVault(alice, address(vaultTokenA));
         _optInOperatorVault(alice, address(vaultTokenB));
-        //_optInOperatorL1(alice, validatorManagerAddress);
+        //_optInOperatorL1(alice, balancer);
 
-        _setL1Limit(bob, validatorManagerAddress, 2, 10000 * 10**6, _delegator2);
-        _setL1Limit(bob, validatorManagerAddress, 2, 10 * 10**18, _delegator3);
+        _setL1Limit(curatorOwner2, balancer, 2, 10000 * 10**6, _delegator2);
+        _setL1Limit(curatorOwner3, balancer, 2, 10 * 10**18, _delegator3);
 
         // Define stakes without normalization
         uint256 stakeA = 10000 * 10**6; // 10,000 TokenA (6 decimals)
@@ -2558,13 +2564,13 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
     }
 
         function test_vaultManager_UpdateVaultMaxL1Limit_NoRevert() public {
-            vm.startPrank(validatorManagerAddress);
+            vm.startPrank(l1Owner);
             vaultManager.updateVaultMaxL1Limit(address(vault), collateralClassId, 500 ether);
             vm.stopPrank();
         }
 
         function test_vaultManager_UpdateVaultMaxL1Limit_DisableEnable() public {
-            vm.startPrank(validatorManagerAddress);
+            vm.startPrank(l1Owner);
             // disable
             vaultManager.updateVaultMaxL1Limit(address(vault), collateralClassId, 0);
             // re-enable with new limit
@@ -2576,18 +2582,18 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
     function test_vaultManager_RegisterMultipleVaults() public {
         // Setup additional asset class
         uint96 collateralClass2 = 2;
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         middleware.addCollateralClass(collateralClass2, 1 ether, 0, address(collateral2));
         middleware.activateSecondaryCollateralClass(collateralClass2);
         vm.stopPrank();
 
         // Register vault2 with asset class 1
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vaultManager.registerVault(address(vault2), 1, 2000 ether);
         vm.stopPrank();
 
         // Register vault3 with asset class 2
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vaultManager.registerVault(address(vault3), collateralClass2, 1500 ether);
         vm.stopPrank();
 
@@ -2605,7 +2611,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
 
     function test_vaultManager_RegisterVault_ErrorConditions() public {
         // Test registering with zero limit
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vm.expectRevert(abi.encodeWithSelector(
             IMiddlewareVaultManager.MiddlewareVaultManager__ZeroVaultMaxL1Limit.selector
         ));
@@ -2613,7 +2619,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         vm.stopPrank();
 
         // Test registering already registered vault
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vm.expectRevert(abi.encodeWithSelector(
             IMiddlewareVaultManager.MiddlewareVaultManager__VaultAlreadyRegistered.selector
         ));
@@ -2621,7 +2627,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         vm.stopPrank();
 
         // Test registering with inactive asset class
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vm.expectRevert(abi.encodeWithSelector(
             IAvalancheL1Middleware.AvalancheL1Middleware__CollateralClassNotActive.selector,
             99
@@ -2632,7 +2638,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
 
     function test_vaultManager_UpdateVaultMaxL1Limit_ErrorConditions() public {
         // Test updating non-existent vault
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vm.expectRevert(abi.encodeWithSelector(
             IMiddlewareVaultManager.MiddlewareVaultManager__NotVault.selector,
             address(vault2)
@@ -2641,12 +2647,12 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         vm.stopPrank();
 
         // Register vault2 first
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vaultManager.registerVault(address(vault2), 1, 1000 ether);
         vm.stopPrank();
 
         // Test updating with wrong asset class
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vm.expectRevert(abi.encodeWithSelector(
             IMiddlewareVaultManager.MiddlewareVaultManager__WrongVaultCollateralClass.selector
         ));
@@ -2656,12 +2662,12 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
 
     function test_vaultManager_DisableEnableVaults() public {
         // Add collateral2 to asset class 1 so vault3 can be registered with it
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         middleware.addAssetToClass(1, address(collateral2));
         vm.stopPrank();
 
         // Register additional vaults
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vaultManager.registerVault(address(vault2), 1, 2000 ether);
         vaultManager.registerVault(address(vault3), 1, 1500 ether);
         vm.stopPrank();
@@ -2673,7 +2679,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         assertEq(activeVaults.length, 3);
 
         // Disable vault2
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vaultManager.updateVaultMaxL1Limit(address(vault2), 1, 0);
         vm.stopPrank();
 
@@ -2692,7 +2698,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         assertFalse(vault2Found, "vault2 should not be in active vaults");
 
         // Re-enable vault2 with new limit
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vaultManager.updateVaultMaxL1Limit(address(vault2), 1, 2500 ether);
         vm.stopPrank();
 
@@ -2703,12 +2709,12 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
 
     function test_vaultManager_RemoveVault() public {
         // Register vault2
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vaultManager.registerVault(address(vault2), 1, 1000 ether);
         vm.stopPrank();
 
         // Try to remove active vault - should fail
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vm.expectRevert(abi.encodeWithSelector(
             IMiddlewareVaultManager.MiddlewareVaultManager__VaultNotDisabled.selector
         ));
@@ -2716,12 +2722,12 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         vm.stopPrank();
 
         // Disable vault first
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vaultManager.updateVaultMaxL1Limit(address(vault2), 1, 0);
         vm.stopPrank();
 
         // Try to remove immediately - should fail (grace period not passed)
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vm.expectRevert(abi.encodeWithSelector(
             IMiddlewareVaultManager.MiddlewareVaultManager__VaultGracePeriodNotPassed.selector
         ));
@@ -2735,7 +2741,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         uint256 vaultCountBefore = vaultManager.getVaultCount();
 
         // Now removal should work
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vaultManager.removeVault(address(vault2));
         vm.stopPrank();
 
@@ -2744,7 +2750,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         assertEq(vaultManager.getVaultCollateralClass(address(vault2)), 0);
 
         // Try to remove non-existent vault
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vm.expectRevert(abi.encodeWithSelector(
             IMiddlewareVaultManager.MiddlewareVaultManager__NotVault.selector,
             address(vault2)
@@ -2762,7 +2768,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         assertEq(activeVaults[0], address(vault));
 
         // Register vault2
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vaultManager.registerVault(address(vault2), 1, 2000 ether);
         vm.stopPrank();
 
@@ -2774,7 +2780,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         assertEq(activeVaults.length, 2);
 
         // Disable vault2
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vaultManager.updateVaultMaxL1Limit(address(vault2), 1, 0);
         vm.stopPrank();
 
@@ -2798,7 +2804,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
     function test_vaultManager_MultipleCollateralClasses() public {
         // Setup asset class 2
         uint96 collateralClass2 = 2;
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         middleware.addCollateralClass(collateralClass2, 1 ether, 0, address(collateral2));
         middleware.activateSecondaryCollateralClass(collateralClass2);
         vm.stopPrank();
@@ -2806,7 +2812,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         // Setup asset class 3
         Token collateral3 = new Token("MockCollateral3");
         uint96 collateralClass3 = 3;
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         middleware.addCollateralClass(collateralClass3, 2 ether, 0, address(collateral3));
         middleware.activateSecondaryCollateralClass(collateralClass3);
         vm.stopPrank();
@@ -2866,7 +2872,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         vault4.setDelegator(delegator4Address);
 
         // Register vaults with different asset classes
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vaultManager.registerVault(address(vault2), 1, 2000 ether);      // Asset class 1
         vaultManager.registerVault(address(vault3), collateralClass2, 1500 ether); // Asset class 2
         vaultManager.registerVault(address(vault4), collateralClass3, 1000 ether); // Asset class 3
@@ -2879,13 +2885,13 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         assertEq(vaultManager.getVaultCollateralClass(address(vault4)), collateralClass3);
 
         // Test updating limits with correct asset classes
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vaultManager.updateVaultMaxL1Limit(address(vault3), collateralClass2, 2000 ether);
         vaultManager.updateVaultMaxL1Limit(address(vault4), collateralClass3, 1500 ether);
         vm.stopPrank();
 
         // Test error when using wrong asset class
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vm.expectRevert(abi.encodeWithSelector(
             IMiddlewareVaultManager.MiddlewareVaultManager__WrongVaultCollateralClass.selector
         ));
@@ -2895,7 +2901,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
 
     function test_vaultManager_GetVaultAtWithTimes() public {
         // Register additional vaults
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vaultManager.registerVault(address(vault2), 1, 2000 ether);
         vm.stopPrank();
 
@@ -2913,7 +2919,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         assertEq(disabledTime1, 0);
 
         // Disable vault2
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vaultManager.updateVaultMaxL1Limit(address(vault2), 1, 0);
         vm.stopPrank();
 
@@ -2928,7 +2934,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
     function test_vaultManager_ComplexVaultLifecycle() public {
         // Setup asset class 2
         uint96 collateralClass2 = 2;
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         middleware.addCollateralClass(collateralClass2, 1 ether, 0, address(collateral2));
         middleware.activateSecondaryCollateralClass(collateralClass2);
         vm.stopPrank();
@@ -2936,7 +2942,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         uint48 epoch0 = middleware.getCurrentEpoch();
 
         // EPOCH 0: Register vault2 and vault3 during epoch0
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vaultManager.registerVault(address(vault2), 1, 2000 ether);      // vault2 enabled in epoch0
         vaultManager.registerVault(address(vault3), collateralClass2, 1500 ether); // vault3 enabled in epoch0
         vm.stopPrank();
@@ -2948,7 +2954,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         assertEq(vaultManager.getVaults(epoch1).length, 3, "epoch1 should have 3 vaults: vault1 + vault2 + vault3");
 
         // EPOCH 1: Disable vault2 during epoch1
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vaultManager.updateVaultMaxL1Limit(address(vault2), 1, 0);      // vault2 disabled in epoch1
         vm.stopPrank();
 
@@ -2959,7 +2965,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         assertEq(vaultManager.getVaults(epoch2).length, 2, "epoch2 should have 2 vaults: vault1 + vault3 (vault2 disabled)");
 
         // EPOCH 2: Update vault3 limit and re-enable vault2
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vaultManager.updateVaultMaxL1Limit(address(vault3), collateralClass2, 3000 ether); // vault3 limit updated
         vaultManager.updateVaultMaxL1Limit(address(vault2), 1, 2500 ether);         // vault2 re-enabled in epoch2
         vm.stopPrank();
@@ -2998,7 +3004,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         uint256 initialCount = vaultManager.getVaultCount();
         
         // Try to register vault with 0 limit - should fail
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vm.expectRevert(abi.encodeWithSelector(
             IMiddlewareVaultManager.MiddlewareVaultManager__ZeroVaultMaxL1Limit.selector
         ));
@@ -3006,14 +3012,14 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         vm.stopPrank();
         
         // Register vault2 with proper limit first, then disable it
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vaultManager.registerVault(address(vault2), 1, 1000 ether);
         vm.stopPrank();
         
         assertEq(vaultManager.getVaultCount(), initialCount + 1);
         
         // Now disable the vault
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vaultManager.updateVaultMaxL1Limit(address(vault2), 1, 0);
         vm.stopPrank();
         
@@ -3051,5 +3057,45 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         );
         vm.prank(alice);
         middleware.initializeValidatorStakeUpdate(nodeId, newStake);
+    }
+
+    function test_POC_PastEpochCachePoisoning_OperatorRemoved() public {
+        uint96 classId = collateralClassId;
+        uint48 e0 = middleware.getCurrentEpoch();
+
+        // Ground truth for e0 BEFORE any caching (uses dynamic path, not cache)
+        uint256 aliceE0   = middleware.getOperatorStake(alice,   e0, classId);
+        uint256 charlieE0 = middleware.getOperatorStake(charlie, e0, classId);
+        uint256 daveE0    = middleware.getOperatorStake(dave,    e0, classId);
+        uint256 dynamicTotal = aliceE0 + charlieE0 + daveE0;
+        assertGt(charlieE0, 0, "pre: charlie has stake at e0");
+        assertFalse(middleware.totalStakeCached(e0, classId), "pre: e0 not cached");
+
+        // Disable then remove Charlie (Charlie has no nodes in this suite)
+        vm.prank(l1Owner);
+        middleware.disableOperator(charlie);
+        _moveToNextEpochAndCalc(middleware.REMOVAL_DELAY_EPOCHS());
+        vm.prank(l1Owner);
+        middleware.removeOperator(charlie);
+
+        // e0 is now older than SLASHING_WINDOW; uncached getTotalStake must revert via age guard
+        bytes memory epochErr = abi.encodeWithSelector(
+            IAvalancheL1Middleware.AvalancheL1Middleware__EpochError.selector,
+            middleware.getEpochStartTs(e0)
+        );
+        vm.expectRevert(epochErr);
+        middleware.getTotalStake(e0, classId);
+
+        // Attacker poisons cache for old epoch using current operators set (Charlie missing)
+        middleware.calcAndCacheStakes(e0, classId);
+        assertTrue(middleware.totalStakeCached(e0, classId), "cache set for old epoch");
+
+        // Charlie's historic stake at e0 is now read from cache => 0
+        assertEq(middleware.getOperatorStake(charlie, e0, classId), 0, "charlie stake at e0 zeroed by cache");
+
+        // Total stake cache lost Charlie's contribution
+        uint256 poisonedTotal = middleware.getTotalStake(e0, classId);
+        assertEq(poisonedTotal, aliceE0 + daveE0, "poisoned total excludes charlie");
+        assertEq(poisonedTotal + charlieE0, dynamicTotal, "sanity: dynamicTotal = poisoned + lost");
     }
 }

--- a/test/middleware/AvalancheL1MiddlewareTest.t.sol
+++ b/test/middleware/AvalancheL1MiddlewareTest.t.sol
@@ -218,10 +218,8 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         // Confirm node – push ack then complete(0)
         bytes32 vId = IBalancerValidatorManager(balancer).getNodeValidationID(_nodeBytes(nodeId));
         _pushRegistrationAck(vId, true);
-        vm.startPrank(alice);
-        middleware.completeValidatorRegistration(alice, nodeId, 0);
+        middleware.completeValidatorRegistration(0);
         middleware.calcAndCacheNodeStakeForAllOperators();
-        vm.stopPrank();
 
         // Should be active next epoch
         epoch = _calcAndWarpOneEpoch();
@@ -258,8 +256,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
             Validator memory v = IBalancerValidatorManager(balancer).getValidator(vId);
             _pushWeight(vId, uint64(v.sentNonce), scaled);
         }
-        vm.prank(alice);
-        middleware.completeStakeUpdate(nodeId, 0);
+        middleware.completeStakeUpdate(0);
         middleware.calcAndCacheNodeStakeForAllOperators();
 
         updatedNodeWeight = middleware.nodeStakeCache(epoch, validationID);
@@ -298,8 +295,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
             Validator memory v = IBalancerValidatorManager(balancer).getValidator(vId);
             _pushWeight(vId, uint64(v.sentNonce), scaled);
         }
-        vm.prank(alice);
-        middleware.completeStakeUpdate(nodeId, 0);
+        middleware.completeStakeUpdate(0);
         middleware.calcAndCacheNodeStakeForAllOperators();
 
         epoch = _calcAndWarpOneEpoch();
@@ -599,8 +595,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
 
         // Confirm node - push ack then complete(0)
         _pushRegistrationAck(validationID, true);
-        vm.prank(alice);
-        middleware.completeValidatorRegistration(alice, nodeId, 0);
+        middleware.completeValidatorRegistration(0);
 
         // Warp +1 epoch and check that the node is truly active
         epoch = _calcAndWarpOneEpoch();
@@ -645,8 +640,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
 
         // Confirm node again - always push ack, then complete(0)
         _pushRegistrationAck(newValidationID, true);
-        vm.prank(alice);
-        middleware.completeValidatorRegistration(alice, nodeId, 0);
+        middleware.completeValidatorRegistration(0);
 
         // Warp another epoch and verify stake
         epoch = _calcAndWarpOneEpoch();
@@ -701,7 +695,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         // Try to complete stake update before ack - should revert
         vm.prank(alice);
         vm.expectRevert();
-        middleware.completeStakeUpdate(nodeId, 0);
+        middleware.completeStakeUpdate(0);
         
         // First complete the stake update, then remove the node
         {
@@ -709,8 +703,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
             Validator memory v = IBalancerValidatorManager(balancer).getValidator(validationID);
             _pushWeight(validationID, uint64(v.sentNonce), scaled);
         }
-        vm.prank(alice);
-        middleware.completeStakeUpdate(nodeId, 0);
+        middleware.completeStakeUpdate(0);
         
         // Verify update was processed and no longer pending
         bool stillPending = IBalancerValidatorManager(balancer).isValidatorPendingWeightUpdate(validationID);
@@ -806,7 +799,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         for (uint256 i = 0; i < nodeCount; i++) {
             _pushRegistrationAck(validationIds[i], true);
             vm.prank(alice);
-            middleware.completeValidatorRegistration(alice, nodeIds[i], 0);
+            middleware.completeValidatorRegistration(0);
             isActive[i] = true;
         }
 
@@ -890,7 +883,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
                 // Confirm the new registration
                 _pushRegistrationAck(newValID, true);
                 vm.prank(alice);
-                middleware.completeValidatorRegistration(alice, nodeIds[i], 0);
+                middleware.completeValidatorRegistration(0);
                 isActive[i] = true;
 
                 // Verify that the oldVal ID remains at stake=0
@@ -1001,7 +994,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         for (uint256 i = 0; i < nodeCount; i++) {
             _pushRegistrationAck(validationIds[i], true);
             vm.prank(alice);
-            middleware.completeValidatorRegistration(alice, nodeIds[i], 0);
+            middleware.completeValidatorRegistration(0);
             isActive[i] = true;
         }
         epoch = _calcAndWarpOneEpoch();
@@ -1061,7 +1054,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
                 Validator memory v = IBalancerValidatorManager(balancer).getValidator(vid);
                 _pushWeight(vid, uint64(v.sentNonce), scaled);
                 vm.prank(alice);
-                middleware.completeStakeUpdate(nodeIds[i], 0);
+                middleware.completeStakeUpdate(0);
             }
         }
 
@@ -1208,14 +1201,13 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         for (uint256 i = 0; i < nodeCountA; i++) {
             _pushRegistrationAck(validationIdsA[i], true);
             vm.prank(alice);
-            middleware.completeValidatorRegistration(alice, nodeIdsA[i], 0);
+            middleware.completeValidatorRegistration(0);
             isActiveA[i] = true;
         }
 
         for (uint256 i = 0; i < nodeCountB; i++) {
             _pushRegistrationAck(validationIdsB[i], true);
-            vm.prank(charlie);
-            middleware.completeValidatorRegistration(charlie, nodeIdsB[i], 0);
+                    middleware.completeValidatorRegistration(0);
             isActiveB[i] = true;
         }
 
@@ -1261,7 +1253,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
                 Validator memory v = IBalancerValidatorManager(balancer).getValidator(vid);
                 _pushWeight(vid, uint64(v.sentNonce), scaled);
                 vm.prank(alice);
-                middleware.completeStakeUpdate(nodeIdsA[i], 0);
+                middleware.completeStakeUpdate(0);
             }
         }
 
@@ -1300,8 +1292,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
                 uint64 scaled = StakeConversion.stakeToWeight(newStake, middleware.WEIGHT_SCALE_FACTOR());
                 Validator memory v = IBalancerValidatorManager(balancer).getValidator(vid);
                 _pushWeight(vid, uint64(v.sentNonce), scaled);
-                vm.prank(charlie);
-                middleware.completeStakeUpdate(nodeIdsB[i], 0);
+                        middleware.completeStakeUpdate(0);
             }
         }
 
@@ -1691,8 +1682,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         
         bytes memory expectedError = abi.encodeWithSelector(
             IAvalancheL1Middleware.AvalancheL1Middleware__ManualEpochUpdateRequired.selector,
-            currentEpochAfterWarp,
-            maxAutoUpdates
+            currentEpochAfterWarp // epochsPending
         );
         vm.expectRevert(expectedError);
         middleware.calcAndCacheNodeStakeForAllOperators();
@@ -1723,8 +1713,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
 
         bytes memory expectedRevertError = abi.encodeWithSelector(
             IAvalancheL1Middleware.AvalancheL1Middleware__ManualEpochUpdateRequired.selector,
-            currentEpochAfterWarp,
-            maxAutoUpdates
+            currentEpochAfterWarp
         );
         vm.expectRevert(expectedRevertError);
         middleware.calcAndCacheNodeStakeForAllOperators();
@@ -2004,7 +1993,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
 
         _pushRegistrationAck(validationID_A1, true);
         vm.prank(operatorA);
-        middleware.completeValidatorRegistration(operatorA, sharedNodeId_X, 0);
+        middleware.completeValidatorRegistration(0);
         
         // Move to next epoch so validator becomes active
         _calcAndWarpOneEpoch();
@@ -2069,7 +2058,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         
         _pushRegistrationAck(validationID_B2, true);
         vm.prank(operatorB);
-        middleware.completeValidatorRegistration(operatorB, sharedNodeId_X, 0);
+        middleware.completeValidatorRegistration(0);
         
         // Move to next epoch so validator becomes active
         _calcAndWarpOneEpoch();
@@ -2281,19 +2270,19 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
         // Complete registrations
         vm.startPrank(alice);
         _pushRegistrationAck(validationID_A, true);
-        middleware.completeValidatorRegistration(alice, nodeId_A, 0);
+        middleware.completeValidatorRegistration(0);
         vm.stopPrank();
         _calcAndWarpOneEpoch();
         
         vm.startPrank(alice);
         _pushRegistrationAck(validationID_B, true);
-        middleware.completeValidatorRegistration(alice, nodeId_B, 0);
+        middleware.completeValidatorRegistration(0);
         vm.stopPrank();
         _calcAndWarpOneEpoch();
         
         vm.startPrank(alice);
         _pushRegistrationAck(validationID_C, true);
-        middleware.completeValidatorRegistration(alice, nodeId_C, 0);
+        middleware.completeValidatorRegistration(0);
         vm.stopPrank();
 
         currentEpoch = _calcAndWarpOneEpoch();
@@ -2396,8 +2385,7 @@ contract AvalancheL1MiddlewareTest is MiddlewareTestBase {
             Validator memory v = IBalancerValidatorManager(balancer).getValidator(validationID);
             _pushWeight(validationID, uint64(v.sentNonce), scaled);
         }
-        vm.prank(alice);
-        middleware.completeStakeUpdate(nodeId, 0);
+        middleware.completeStakeUpdate(0);
         
         // NOW the cache should be updated for next epoch
         uint256 confirmedStake = middleware.nodeStakeCache(nextEpoch, validationID);

--- a/test/middleware/CollateralClassRegistryTest.t.sol
+++ b/test/middleware/CollateralClassRegistryTest.t.sol
@@ -182,16 +182,17 @@ contract CollateralClassRegistryTest is Test {
     }
 
     function test_RevertOnRemoveNonexistentAsset() public {
-        collateralClassRegistry.addAssetToClass(1, alice);
-        // Try remove bob from class 1
+        // use a real ERC20 as the added asset
+        collateralClassRegistry.addAssetToClass(1, tokenB);
+        // try removing a different (non-added) ERC20
         vm.expectRevert(ICollateralClassRegistry.CollateralClassRegistry__AssetNotFound.selector);
-        collateralClassRegistry.removeAssetFromClass(1, bob);
+        collateralClassRegistry.removeAssetFromClass(1, tokenC);
     }
 
     function test_RevertOnAddDuplicateAsset() public {
-        collateralClassRegistry.addAssetToClass(1, alice);
+        collateralClassRegistry.addAssetToClass(1, tokenB);
         vm.expectRevert(ICollateralClassRegistry.CollateralClassRegistry__AssetAlreadyRegistered.selector);
-        collateralClassRegistry.addAssetToClass(1, alice);
+        collateralClassRegistry.addAssetToClass(1, tokenB);
     }
 
     function test_RevertOnGetMinStakeForNonExistentClass() public {

--- a/test/middleware/CollateralClassRegistryTest.t.sol
+++ b/test/middleware/CollateralClassRegistryTest.t.sol
@@ -9,6 +9,7 @@ import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import {CollateralClassRegistry} from "../../src/contracts/middleware/CollateralClassRegistry.sol";
 import {ICollateralClassRegistry} from "../../src/interfaces/middleware/ICollateralClassRegistry.sol";
 import {MockCollateralClassRegistry} from "../mocks/MockCollateralClassRegistry.sol";
+import {ERC20WithDecimals} from "../mocks/MockERC20WithDecimals.sol";
 
 contract CollateralClassRegistryTest is Test {
     MockCollateralClassRegistry collateralClassRegistry;
@@ -24,9 +25,9 @@ contract CollateralClassRegistryTest is Test {
         owner = address(this);
         alice = makeAddr("alice");
         bob = makeAddr("bob");
-        tokenA = makeAddr("tokenA");
-        tokenB = makeAddr("tokenB");
-        tokenC = makeAddr("tokenC");
+        tokenA = address(new ERC20WithDecimals("tokenA", "tA", 18));
+        tokenB = address(new ERC20WithDecimals("tokenB", "tB", 18));
+        tokenC = address(new ERC20WithDecimals("tokenC", "tC", 18));
 
         // Deploy the new child CollateralClassRegistry
         collateralClassRegistry = new MockCollateralClassRegistry(owner);
@@ -157,7 +158,7 @@ contract CollateralClassRegistryTest is Test {
 
     function test__addCollateralClassAndCheckStakes() public {
         // Add new class #3
-        collateralClassRegistry.addCollateralClass(3, 123, 456, address(tokenC));
+        collateralClassRegistry.addCollateralClass(3, 123, 456, tokenC);
 
         (uint256 primaryCollateralMinStake, uint256 primaryCollateralMaxStake) = collateralClassRegistry.getClassStakingRequirements(3);
         assertEq(primaryCollateralMinStake, 123, "Expected primaryCollateralMinStake = 123 for class 3");

--- a/test/middleware/MiddlewareTestBase.t.sol
+++ b/test/middleware/MiddlewareTestBase.t.sol
@@ -30,7 +30,6 @@ import {VaultTokenized} from "../../src/contracts/vault/VaultTokenized.sol";
 import {L1RestakeDelegator} from "../../src/contracts/delegator/L1RestakeDelegator.sol";
 import {MiddlewareHelperConfig} from "../../script/middleware/anvil/MiddlewareHelperConfig.s.sol";
 import {MockWarpMessenger} from "../mocks/MockWarpMessenger.sol";
-import {MockBalancerValidatorManager} from "../mocks/MockBalancerValidatorManager.sol";
 import {DeployBalancerValidatorManager} from "lib/suzaku-contracts-library/script/ValidatorManager/DeployBalancerValidatorManager.s.sol";
 
 import {BalancerValidatorManager} from
@@ -108,8 +107,7 @@ abstract contract MiddlewareTestBase is Test {
     address internal validatorManager;  // ValidatorManager proxy  
     address internal secModule;     // PoASecurityModule
     
-    // Keep the mock for existing tests
-    MockBalancerValidatorManager internal mockValidatorManager;
+
 
     function setUp() public virtual {
         owner = address(this);
@@ -847,7 +845,7 @@ abstract contract MiddlewareTestBase is Test {
     ) private returns (uint256 actualNodeCount) {
         for (uint256 i = 0; i < nodeCount; i++) {
             bytes32 nodeId = keccak256(abi.encodePacked(operator, block.timestamp, i));
-            uint256 stakeAmount = _calculateStakeAmount(operator, stake_, minMultiplier);
+            uint256 stakeAmount = _calculateStakeAmount(stake_, minMultiplier);
             
             if (!_tryRegisterNode(operator, nodeId, stakeAmount)) {
                 break;
@@ -859,7 +857,7 @@ abstract contract MiddlewareTestBase is Test {
             _tempValidationIDs.push(validationID);
             
             if (confirmImmediately) {
-                _completeNodeRegistration(operator, nodeId, validationID, actualNodeCount, nodeCount);
+                _completeNodeRegistration(validationID, actualNodeCount, nodeCount);
             }
             
             uint256 weight = middleware.nodeStakeCache(middleware.getCurrentEpoch(), validationID);
@@ -871,7 +869,6 @@ abstract contract MiddlewareTestBase is Test {
     }
     
     function _calculateStakeAmount(
-        address operator,
         uint256 stake_,
         uint256 minMultiplier
     ) internal returns (uint256) {
@@ -914,23 +911,13 @@ abstract contract MiddlewareTestBase is Test {
     }
     
     function _completeNodeRegistration(
-        address operator,
-        bytes32 nodeId,
         bytes32 validationID,
         uint256 currentCount,
         uint256 totalCount
     ) internal {
-        // Push registration acceptance in the warp messenger
         uint32 msgIdx = _pushRegistrationAck(validationID, true);
-        
-        vm.prank(operator);
-        middleware.completeValidatorRegistration(operator, nodeId, msgIdx);
-        
-        // If the caller is confirming a batch, space them across epochs
-        // so we never pile multiple weight changes into the same churn window.
-        if (currentCount + 1 < totalCount) {
-            _calcAndWarpOneEpoch();
-        }
+        middleware.completeValidatorRegistration(msgIdx); // permissionless
+        if (currentCount + 1 < totalCount) _calcAndWarpOneEpoch();
     }
 
     function _stakeOrRemoveNodes(
@@ -987,9 +974,7 @@ abstract contract MiddlewareTestBase is Test {
                 
                 // Push weight update in the warp messenger
                 uint32 stakeMsgIdx = _pushWeight(validationIdForUpdate, nextNonce, scaledWeight);
-                
-                vm.prank(operator);
-                middleware.completeStakeUpdate(nodeIds[i], stakeMsgIdx);
+                middleware.completeStakeUpdate(stakeMsgIdx); // permissionless
             }
         }
     }

--- a/test/middleware/MiddlewareTestBase.t.sol
+++ b/test/middleware/MiddlewareTestBase.t.sol
@@ -62,8 +62,12 @@ abstract contract MiddlewareTestBase is Test {
     // Constants
     address constant WARP = 0x0200000000000000000000000000000000000005;
     
-    address internal owner;
-    address internal validatorManagerAddress;
+    address internal owner;  // TODO: Deprecate this
+    address internal protocolOwner;  // Owns factories, registries, collateral
+    address internal l1Owner;  // Owns balancer, middleware, vaultManager, rewards
+    address internal curatorOwner1;  // Owns vault1 and its delegator
+    address internal curatorOwner2;  // Owns vault2 and its delegator
+    address internal curatorOwner3;  // Owns vault3 and its delegator
     address internal alice;
     uint256 internal alicePrivateKey;
     address internal bob;
@@ -111,6 +115,11 @@ abstract contract MiddlewareTestBase is Test {
 
     function setUp() public virtual {
         owner = address(this);
+        protocolOwner = makeAddr("protocolOwner");
+        l1Owner = makeAddr("l1Owner");
+        curatorOwner1 = makeAddr("curatorOwner1");
+        curatorOwner2 = makeAddr("curatorOwner2");
+        curatorOwner3 = makeAddr("curatorOwner3");
         (alice, alicePrivateKey) = makeAddrAndKey("alice");
         (bob, bobPrivateKey) = makeAddrAndKey("bob");
         (charlie, charliePrivateKey) = makeAddrAndKey("charlie");
@@ -120,14 +129,14 @@ abstract contract MiddlewareTestBase is Test {
         tokenA = makeAddr("tokenA");
         tokenB = makeAddr("tokenB");
         feeCollectorAddress = makeAddr("feeCollector");
-        vaultFactory = new VaultFactory(owner);
-        delegatorFactory = new DelegatorFactory(owner);
-        slasherFactory = new SlasherFactory(owner);
+        vaultFactory = new VaultFactory(protocolOwner);
+        delegatorFactory = new DelegatorFactory(protocolOwner);
+        slasherFactory = new SlasherFactory(protocolOwner);
         l1Registry = new L1Registry(
             payable(feeCollectorAddress), // fee collector
             0.01 ether, // initial register fee
             1 ether, // MAX_FEE
-            owner
+            protocolOwner
         );
         operatorRegistry = new OperatorRegistry();
 
@@ -160,9 +169,12 @@ abstract contract MiddlewareTestBase is Test {
             address WARP_MESSENGER_ADDR = WARP;
             vm.etch(WARP_MESSENGER_ADDR, address(messenger).code);
         }
+
         
-        // The "L1 address" the rest of this test suite uses
-        validatorManagerAddress = balancer;
+        // Transfer balancer ownership to l1Owner
+        address currentBalancerOwner = BalancerValidatorManager(balancer).owner();
+        vm.prank(currentBalancerOwner);
+        BalancerValidatorManager(balancer).transferOwnership(l1Owner);
 
         operatorVaultOptInService = new OperatorVaultOptInService(
             address(operatorRegistry), // whoRegistry
@@ -178,6 +190,7 @@ abstract contract MiddlewareTestBase is Test {
 
         // Whitelist a vault implementation
         address vaultImpl = address(new VaultTokenized(address(vaultFactory)));
+        vm.prank(protocolOwner);
         vaultFactory.whitelist(vaultImpl);
 
         // Whitelist L1RestakeDelegator
@@ -191,6 +204,7 @@ abstract contract MiddlewareTestBase is Test {
                 delegatorFactory.totalTypes()
             )
         );
+        vm.prank(protocolOwner);
         delegatorFactory.whitelist(l1RestakeDelegatorImpl);
 
         // Create a test collateral token
@@ -207,7 +221,7 @@ abstract contract MiddlewareTestBase is Test {
         uint64 lastVersion = vaultFactory.lastVersion();
         address vaultAddress = vaultFactory.create(
             lastVersion,
-            bob,
+            curatorOwner1,
             abi.encode(
                 IVaultTokenized.InitParams({
                     collateral: address(collateral),
@@ -216,11 +230,11 @@ abstract contract MiddlewareTestBase is Test {
                     depositWhitelist: false,
                     isDepositLimit: false,
                     depositLimit: 0,
-                    defaultAdminRoleHolder: bob,
-                    depositWhitelistSetRoleHolder: bob,
-                    depositorWhitelistRoleHolder: bob,
-                    isDepositLimitSetRoleHolder: bob,
-                    depositLimitSetRoleHolder: bob,
+                    defaultAdminRoleHolder: curatorOwner1,
+                    depositWhitelistSetRoleHolder: curatorOwner1,
+                    depositorWhitelistRoleHolder: curatorOwner1,
+                    isDepositLimitSetRoleHolder: curatorOwner1,
+                    depositLimitSetRoleHolder: curatorOwner1,
                     name: "Test",
                     symbol: "TEST"
                 })
@@ -234,7 +248,7 @@ abstract contract MiddlewareTestBase is Test {
         // Deploy vault2 (using same collateral)
         address vault2Address = vaultFactory.create(
             lastVersion,
-            bob,
+            curatorOwner2,
             abi.encode(
                 IVaultTokenized.InitParams({
                     collateral: address(collateral),
@@ -243,11 +257,11 @@ abstract contract MiddlewareTestBase is Test {
                     depositWhitelist: false,
                     isDepositLimit: false,
                     depositLimit: 0,
-                    defaultAdminRoleHolder: bob,
-                    depositWhitelistSetRoleHolder: bob,
-                    depositorWhitelistRoleHolder: bob,
-                    isDepositLimitSetRoleHolder: bob,
-                    depositLimitSetRoleHolder: bob,
+                    defaultAdminRoleHolder: curatorOwner2,
+                    depositWhitelistSetRoleHolder: curatorOwner2,
+                    depositorWhitelistRoleHolder: curatorOwner2,
+                    isDepositLimitSetRoleHolder: curatorOwner2,
+                    depositLimitSetRoleHolder: curatorOwner2,
                     name: "Test2",
                     symbol: "TEST2"
                 })
@@ -261,7 +275,7 @@ abstract contract MiddlewareTestBase is Test {
         // Deploy vault3 (using new collateral)
         address vault3Address = vaultFactory.create(
             lastVersion,
-            bob,
+            curatorOwner3,
             abi.encode(
                 IVaultTokenized.InitParams({
                     collateral: address(collateral2),
@@ -270,11 +284,11 @@ abstract contract MiddlewareTestBase is Test {
                     depositWhitelist: false,
                     isDepositLimit: false,
                     depositLimit: 0,
-                    defaultAdminRoleHolder: bob,
-                    depositWhitelistSetRoleHolder: bob,
-                    depositorWhitelistRoleHolder: bob,
-                    isDepositLimitSetRoleHolder: bob,
-                    depositLimitSetRoleHolder: bob,
+                    defaultAdminRoleHolder: curatorOwner3,
+                    depositWhitelistSetRoleHolder: curatorOwner3,
+                    depositorWhitelistRoleHolder: curatorOwner3,
+                    isDepositLimitSetRoleHolder: curatorOwner3,
+                    depositLimitSetRoleHolder: curatorOwner3,
                     name: "Test3",
                     symbol: "TEST3"
                 })
@@ -287,9 +301,9 @@ abstract contract MiddlewareTestBase is Test {
 
         // Setup delegator for vault1
         address[] memory l1LimitSetRoleHolders = new address[](1);
-        l1LimitSetRoleHolders[0] = bob;
+        l1LimitSetRoleHolders[0] = curatorOwner1;
         address[] memory operatorL1SharesSetRoleHolders = new address[](1);
-        operatorL1SharesSetRoleHolders[0] = bob;
+        operatorL1SharesSetRoleHolders[0] = curatorOwner1;
 
         address delegatorAddress = delegatorFactory.create(
             0,
@@ -298,9 +312,9 @@ abstract contract MiddlewareTestBase is Test {
                 abi.encode(
                     IL1RestakeDelegator.InitParams({
                         baseParams: IBaseDelegator.BaseParams({
-                            defaultAdminRoleHolder: bob,
+                            defaultAdminRoleHolder: curatorOwner1,
                             hook: address(0),
-                            hookSetRoleHolder: bob
+                            hookSetRoleHolder: curatorOwner1
                         }),
                         l1LimitSetRoleHolders: l1LimitSetRoleHolders,
                         operatorL1SharesSetRoleHolders: operatorL1SharesSetRoleHolders
@@ -312,6 +326,11 @@ abstract contract MiddlewareTestBase is Test {
         delegator = L1RestakeDelegator(delegatorAddress);
 
         // Setup delegator for vault2
+        address[] memory l1LimitSetRoleHolders2 = new address[](1);
+        l1LimitSetRoleHolders2[0] = curatorOwner2;
+        address[] memory operatorL1SharesSetRoleHolders2 = new address[](1);
+        operatorL1SharesSetRoleHolders2[0] = curatorOwner2;
+        
         address delegator2Address = delegatorFactory.create(
             0,
             abi.encode(
@@ -319,12 +338,12 @@ abstract contract MiddlewareTestBase is Test {
                 abi.encode(
                     IL1RestakeDelegator.InitParams({
                         baseParams: IBaseDelegator.BaseParams({
-                            defaultAdminRoleHolder: bob,
+                            defaultAdminRoleHolder: curatorOwner2,
                             hook: address(0),
-                            hookSetRoleHolder: bob
+                            hookSetRoleHolder: curatorOwner2
                         }),
-                        l1LimitSetRoleHolders: l1LimitSetRoleHolders,
-                        operatorL1SharesSetRoleHolders: operatorL1SharesSetRoleHolders
+                        l1LimitSetRoleHolders: l1LimitSetRoleHolders2,
+                        operatorL1SharesSetRoleHolders: operatorL1SharesSetRoleHolders2
                     })
                 )
             )
@@ -333,6 +352,11 @@ abstract contract MiddlewareTestBase is Test {
         delegator2 = L1RestakeDelegator(delegator2Address);
 
         // Setup delegator for vault3
+        address[] memory l1LimitSetRoleHolders3 = new address[](1);
+        l1LimitSetRoleHolders3[0] = curatorOwner3;
+        address[] memory operatorL1SharesSetRoleHolders3 = new address[](1);
+        operatorL1SharesSetRoleHolders3[0] = curatorOwner3;
+        
         address delegator3Address = delegatorFactory.create(
             0,
             abi.encode(
@@ -340,12 +364,12 @@ abstract contract MiddlewareTestBase is Test {
                 abi.encode(
                     IL1RestakeDelegator.InitParams({
                         baseParams: IBaseDelegator.BaseParams({
-                            defaultAdminRoleHolder: bob,
+                            defaultAdminRoleHolder: curatorOwner3,
                             hook: address(0),
-                            hookSetRoleHolder: bob
+                            hookSetRoleHolder: curatorOwner3
                         }),
-                        l1LimitSetRoleHolders: l1LimitSetRoleHolders,
-                        operatorL1SharesSetRoleHolders: operatorL1SharesSetRoleHolders
+                        l1LimitSetRoleHolders: l1LimitSetRoleHolders3,
+                        operatorL1SharesSetRoleHolders: operatorL1SharesSetRoleHolders3
                     })
                 )
             )
@@ -354,20 +378,20 @@ abstract contract MiddlewareTestBase is Test {
         delegator3 = L1RestakeDelegator(delegator3Address);
 
         // Set the delegator in vault1
-        vm.prank(bob);
+        vm.prank(curatorOwner1);
         vault.setDelegator(delegatorAddress);
 
         // Set the delegator in vault2
-        vm.prank(bob);
+        vm.prank(curatorOwner2);
         vault2.setDelegator(delegator2Address);
 
         // Set the delegator in vault3
-        vm.prank(bob);
+        vm.prank(curatorOwner3);
         vault3.setDelegator(delegator3Address);
 
         // Deploy the middleware
         AvalancheL1MiddlewareSettings memory middlewareSettings = AvalancheL1MiddlewareSettings({
-            l1ValidatorManager: validatorManagerAddress,
+            balancer: balancer,
             operatorRegistry: address(operatorRegistry),
             vaultRegistry: address(vaultFactory),
             operatorL1Optin: address(operatorL1OptInService),
@@ -378,42 +402,43 @@ abstract contract MiddlewareTestBase is Test {
 
         middleware = new AvalancheL1Middleware(
             middlewareSettings,
-            owner,
+            l1Owner,
             primaryCollateral,
             primaryCollateralMaxStake,
             primaryCollateralMinStake,
             primaryCollateralWeightScaleFactor
         );
 
-        vaultManager = new MiddlewareVaultManager(address(vaultFactory), owner, address(middleware), 24); // 24 epoch delay
+        vaultManager = new MiddlewareVaultManager(address(vaultFactory), l1Owner, address(middleware), 24); // 24 epoch delay
         // middleware.addCollateralClass(2, primaryCollateralMinStake, primaryCollateralMaxStake);
         // middleware.activateSecondaryCollateralClass(0);
 
         // Set the vault manager in the middleware
+        vm.prank(l1Owner);
         middleware.setVaultManager(address(vaultManager));
 
-        middleware.transferOwnership(validatorManagerAddress);
-        vaultManager.transferOwnership(validatorManagerAddress);
+        // Keep middleware and vaultManager owned by the l1Owner
+        // Do NOT transfer ownership to anyone else as per the new architecture
 
         // Setup middleware as a security module on the Balancer
         // Note: The deployment script sets up an initial security module, but we need to add middleware
         {
-            address balOwner = BalancerValidatorManager(balancer).owner();
             uint64 maxWeight = uint64(1_000_000_000); // 1e9 weight cap (>> enough for tests)
-            vm.prank(balOwner);
+            vm.prank(l1Owner);
             BalancerValidatorManager(balancer).setUpSecurityModule(address(middleware), maxWeight);
         }
 
         // The real stack handles ownership during deployment
 
-        // Give validatorManager some ETH to pay the registration fee
-        vm.deal(validatorManagerAddress, 1 ether);
+        // Give l1 owner some ETH to pay the registration fee
+        vm.deal(l1Owner, 1 ether);
 
-        _registerL1(validatorManagerAddress, address(middleware));
+        // Register the balancer as the L1 (not the raw validator manager)
+        _registerL1(balancer, address(middleware));
         collateralClassId = 1;
         maxVaultL1Limit = 3000 ether;
 
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         vaultManager.registerVault(address(vault), collateralClassId, maxVaultL1Limit);
         vm.stopPrank();
 
@@ -423,9 +448,9 @@ abstract contract MiddlewareTestBase is Test {
         _registerOperator(dave, "dave metadata");
 
         // Opt-in operators for L1
-        _optInOperatorL1(alice, validatorManagerAddress);
-        _optInOperatorL1(charlie, validatorManagerAddress);
-        _optInOperatorL1(dave, validatorManagerAddress);
+        _optInOperatorL1(alice, balancer);
+        _optInOperatorL1(charlie, balancer);
+        _optInOperatorL1(dave, balancer);
 
         // Opt-in operators for vaults
         _optInOperatorVault(alice, address(vault));
@@ -437,14 +462,16 @@ abstract contract MiddlewareTestBase is Test {
         _optInOperatorVault(dave, address(vault3));
 
         // Register operators with middleware
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         middleware.registerOperator(alice);
         middleware.registerOperator(charlie);
         middleware.registerOperator(dave);
         vm.stopPrank();
 
-        // Grant whitelist deposit role to staker
-        _grantDepositorWhitelistRole(bob, staker);
+        // Grant whitelist deposit role to staker for all vaults
+        _grantDepositorWhitelistRole(curatorOwner1, staker, vault);
+        _grantDepositorWhitelistRole(curatorOwner2, staker, vault2);
+        _grantDepositorWhitelistRole(curatorOwner3, staker, vault3);
 
         uint256 l1Limit = 2500 ether;
 
@@ -456,8 +483,8 @@ abstract contract MiddlewareTestBase is Test {
         (depositedAmount, mintedShares) = vault.deposit(staker, 550_000_000_000_000);
         vm.stopPrank();
 
-        _setL1Limit(bob, validatorManagerAddress, collateralClassId, l1Limit, delegator);
-        _setOperatorL1Shares(bob, validatorManagerAddress, collateralClassId, alice, mintedShares, delegator);
+        _setL1Limit(curatorOwner1, balancer, collateralClassId, l1Limit, delegator);
+        _setOperatorL1Shares(curatorOwner1, balancer, collateralClassId, alice, mintedShares, delegator);
 
         // Setup Charlie as operator for both vault1 and vault2
         // First deposit to vault1
@@ -469,7 +496,7 @@ abstract contract MiddlewareTestBase is Test {
         vm.stopPrank();
 
         // Add Charlie's shares from vault1 (existing limit is already set)
-        _setOperatorL1Shares(bob, validatorManagerAddress, collateralClassId, charlie, charlieVault1Shares, delegator);
+        _setOperatorL1Shares(curatorOwner1, balancer, collateralClassId, charlie, charlieVault1Shares, delegator);
 
         // Then deposit to vault2
         uint256 charlieVault2DepositAmount = 220_000_000_000_000;
@@ -480,7 +507,7 @@ abstract contract MiddlewareTestBase is Test {
         vm.stopPrank();
 
         // Set L1 shares for Charlie from vault2
-        _setOperatorL1Shares(bob, validatorManagerAddress, collateralClassId, charlie, charlieVault2Shares, delegator2);
+        _setOperatorL1Shares(curatorOwner2, balancer, collateralClassId, charlie, charlieVault2Shares, delegator2);
 
         // Setup Dave as operator for vault2
         uint256 daveVault2DepositAmount = 200_000_000_000_000;
@@ -491,7 +518,7 @@ abstract contract MiddlewareTestBase is Test {
         vm.stopPrank();
 
         // Set L1 shares for Dave from vault2
-        _setOperatorL1Shares(bob, validatorManagerAddress, collateralClassId, dave, daveVault2Shares, delegator2);
+        _setOperatorL1Shares(curatorOwner2, balancer, collateralClassId, dave, daveVault2Shares, delegator2);
 
         // Setup vault3 with new collateral for Alice, Charlie and Dave
         uint256 vault3DepositAmount = 100_000_000_000_000;
@@ -518,9 +545,9 @@ abstract contract MiddlewareTestBase is Test {
         vm.stopPrank();
 
         // Set L1 shares for all three operators from vault3
-        _setOperatorL1Shares(bob, validatorManagerAddress, 2, alice, aliceVault3MintedShares, delegator3);
-        _setOperatorL1Shares(bob, validatorManagerAddress, 2, charlie, charlieVault3MintedShares, delegator3);
-        _setOperatorL1Shares(bob, validatorManagerAddress, 2, dave, daveVault3MintedShares, delegator3);
+        _setOperatorL1Shares(curatorOwner3, balancer, 2, alice, aliceVault3MintedShares, delegator3);
+        _setOperatorL1Shares(curatorOwner3, balancer, 2, charlie, charlieVault3MintedShares, delegator3);
+        _setOperatorL1Shares(curatorOwner3, balancer, 2, dave, daveVault3MintedShares, delegator3);
 
         // Alice Operator for vault1 has 200_000_000_002_000 deposited
         // Alice Operator for vault3 has 100_000_000_000_000 deposited
@@ -615,16 +642,18 @@ abstract contract MiddlewareTestBase is Test {
     }
 
     function _registerL1(address _l1, address _middleware) internal {
-        // L1Registry expects the call to come from the owner of the validator manager
-        address l1Owner = Ownable(_l1).owner();
-        vm.deal(l1Owner, 1 ether); // Ensure the owner has ETH for registration fee
-        vm.prank(l1Owner);
+        // L1Registry expects the call to come from the owner of the balancer
+        // _l1 should be the balancer address, not the raw validator manager
+        address balancerOwner = Ownable(_l1).owner();
+        vm.deal(balancerOwner, 1 ether); // Ensure the owner has ETH for registration fee
+        vm.prank(balancerOwner);
         l1Registry.registerL1{value: 0.01 ether}(_l1, _middleware, "metadataURL");
     }
 
-    function _grantDepositorWhitelistRole(address user, address account) internal {
+    
+    function _grantDepositorWhitelistRole(address user, address account, VaultTokenized targetVault) internal {
         vm.startPrank(user);
-        VaultTokenized(address(vault)).grantRole(vault.DEPOSITOR_WHITELIST_ROLE(), account);
+        targetVault.grantRole(targetVault.DEPOSITOR_WHITELIST_ROLE(), account);
         vm.stopPrank();
     }
 
@@ -743,7 +772,7 @@ abstract contract MiddlewareTestBase is Test {
     function _syncStakeCache(uint48 epoch) internal {
         uint48 cachedEpoch = middleware.lastGlobalNodeStakeUpdateEpoch();
         if (cachedEpoch < epoch) {
-            vm.prank(validatorManagerAddress);
+            vm.prank(l1Owner);
             middleware.manualProcessNodeStakeCache(epoch - cachedEpoch);
         }
     }
@@ -758,12 +787,25 @@ abstract contract MiddlewareTestBase is Test {
         uint256 l1Limit_,
         L1RestakeDelegator delegator_
     ) internal {
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(l1Owner);
         middleware.addCollateralClass(collateralClassId_, minValidatorStake_, 0, address(collateral_));
         middleware.activateSecondaryCollateralClass(collateralClassId_);
         vaultManager.registerVault(address(vault_), collateralClassId_, maxVaultLimit_);
         vm.stopPrank();
-        _setL1Limit(bob, validatorManagerAddress, collateralClassId_, l1Limit_, delegator_);
+        
+        // Determine the correct curator owner based on which delegator is passed
+        address curatorOwner;
+        if (address(delegator_) == address(delegator)) {
+            curatorOwner = curatorOwner1;
+        } else if (address(delegator_) == address(delegator2)) {
+            curatorOwner = curatorOwner2;
+        } else if (address(delegator_) == address(delegator3)) {
+            curatorOwner = curatorOwner3;
+        } else {
+            revert("Unknown delegator");
+        }
+        
+        _setL1Limit(curatorOwner, balancer, collateralClassId_, l1Limit_, delegator_);
     }
 
     function _warpToLastHourOfCurrentEpoch() internal {

--- a/test/middleware/pocAudit18.t.sol
+++ b/test/middleware/pocAudit18.t.sol
@@ -62,8 +62,7 @@ contract PoCMissingLockingRewards is MiddlewareTestBase {
         middleware.addNode(n1, new bytes(48), _pOwner1(alice), _pOwner1(alice), stake1);
         bytes32 v1 = IBalancerValidatorManager(balancer).getNodeValidationID(_nodeBytes(n1));
         _pushRegistrationAck(v1, true);
-        vm.prank(alice);
-        middleware.completeValidatorRegistration(alice, n1, 0);
+        middleware.completeValidatorRegistration(0);
 
         // --- second node (add + confirm)
         bytes32 n2 = keccak256(abi.encodePacked("alice-n2", block.timestamp));
@@ -71,8 +70,7 @@ contract PoCMissingLockingRewards is MiddlewareTestBase {
         middleware.addNode(n2, new bytes(48), _pOwner1(alice), _pOwner1(alice), stake1);
         bytes32 v2 = IBalancerValidatorManager(balancer).getNodeValidationID(_nodeBytes(n2));
         _pushRegistrationAck(v2, true);
-        vm.prank(alice);
-        middleware.completeValidatorRegistration(alice, n2, 0);
+        middleware.completeValidatorRegistration(0);
 
         // Sanity: two should fit, three should not (in terms of initial availability)
         assertTrue(2 * stake1 <= avail && 3 * stake1 > avail, "bad stake sizing");

--- a/test/middleware/pocAudit19.t.sol
+++ b/test/middleware/pocAudit19.t.sol
@@ -31,8 +31,7 @@ contract PoCIrremovableNode is MiddlewareTestBase {
 
         // Push registration ack, then complete(0)
         _pushRegistrationAck(valId, true);
-        vm.prank(alice);
-        middleware.completeValidatorRegistration(alice, nodeId, 0);
+        middleware.completeValidatorRegistration(0);
 
         assertEq(middleware.getOperatorNodesLength(alice), 1);
 
@@ -45,7 +44,6 @@ contract PoCIrremovableNode is MiddlewareTestBase {
 
         // Push removal ack, then complete(0)
         _pushRemovalAck(valId);
-        vm.prank(alice);
         middleware.completeValidatorRemoval(0);
 
         // Array should be empty now
@@ -63,8 +61,7 @@ contract PoCIrremovableNode is MiddlewareTestBase {
 
         bytes32 valId2 = IBalancerValidatorManager(balancer).getNodeValidationID(_nodeBytes(nodeId));
         _pushRegistrationAck(valId2, true);
-        vm.prank(alice);
-        middleware.completeValidatorRegistration(alice, nodeId, 0);
+        middleware.completeValidatorRegistration(0);
 
         assertEq(middleware.getOperatorNodesLength(alice), 1);
 
@@ -74,7 +71,6 @@ contract PoCIrremovableNode is MiddlewareTestBase {
 
         // Complete removal in the same epoch (push ack, then complete)
         _pushRemovalAck(valId2);
-        vm.prank(alice);
         middleware.completeValidatorRemoval(0);
 
         // Advance to next epoch to finalize caches

--- a/test/middleware/pocAuditOctane.t.sol
+++ b/test/middleware/pocAuditOctane.t.sol
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import {MiddlewareTestBase} from "./MiddlewareTestBase.t.sol";
+import {Test} from "forge-std/Test.sol";
 
 import {AvalancheL1Middleware, AvalancheL1MiddlewareSettings} from
     "../../src/contracts/middleware/AvalancheL1Middleware.sol";
+import {IAvalancheL1Middleware} from "../../src/interfaces/middleware/IAvalancheL1Middleware.sol";
 import {MiddlewareVaultManager} from "../../src/contracts/middleware/MiddlewareVaultManager.sol";
 import {VaultTokenized} from "../../src/contracts/vault/VaultTokenized.sol";
 import {L1RestakeDelegator} from "../../src/contracts/delegator/L1RestakeDelegator.sol";
@@ -19,13 +20,203 @@ import {BalancerValidatorManager} from
 import {ERC20WithDecimals} from "../mocks/MockERC20WithDecimals.sol";
 import {Time} from "@openzeppelin/contracts/utils/types/Time.sol";
 
-contract pocAuditOctane is MiddlewareTestBase {
+// Additional imports needed for standalone test
+import {VaultFactory} from "../../src/contracts/VaultFactory.sol";
+import {DelegatorFactory} from "../../src/contracts/DelegatorFactory.sol";
+import {SlasherFactory} from "../../src/contracts/SlasherFactory.sol";
+import {L1Registry} from "../../src/contracts/L1Registry.sol";
+import {OperatorRegistry} from "../../src/contracts/OperatorRegistry.sol";
+import {OperatorVaultOptInService} from "../../src/contracts/service/OperatorVaultOptInService.sol";
+import {OperatorL1OptInService} from "../../src/contracts/service/OperatorL1OptInService.sol";
+import {DeployBalancerValidatorManager} from "lib/suzaku-contracts-library/script/ValidatorManager/DeployBalancerValidatorManager.s.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {PChainOwner} from "@avalabs/icm-contracts/validator-manager/interfaces/IACP99Manager.sol";
+import {MockWarpMessenger} from "../mocks/MockWarpMessenger.sol";
+import {Token} from "../mocks/Token.sol";
+
+contract pocAuditOctane is Test {
+    // Constants
+    address constant WARP = 0x0200000000000000000000000000000000000005;
+    
+    // State variables
+    VaultFactory vaultFactory;
+    DelegatorFactory delegatorFactory;
+    SlasherFactory slasherFactory;
+    L1Registry l1Registry;
+    OperatorRegistry operatorRegistry;
+    OperatorVaultOptInService operatorVaultOptInService;
+    OperatorL1OptInService operatorL1OptInService;
+    AvalancheL1Middleware middleware;
+    MiddlewareVaultManager vaultManager;
+    
+    address alice;
+    address bob;
+    address staker;
+    address l1Owner;
+    address protocolOwner;
+    address balancer;
+    
+    function setUp() public {
+        // Setup addresses
+        alice = makeAddr("alice");
+        bob = makeAddr("bob");
+        staker = makeAddr("staker");
+        l1Owner = makeAddr("l1Owner");
+        protocolOwner = makeAddr("protocolOwner");
+        
+        // Deploy factories
+        vaultFactory = new VaultFactory(protocolOwner);
+        delegatorFactory = new DelegatorFactory(protocolOwner);
+        slasherFactory = new SlasherFactory(protocolOwner);
+        
+        // Whitelist VaultTokenized implementation
+        address vaultImpl = address(new VaultTokenized(address(vaultFactory)));
+        vm.prank(protocolOwner);
+        vaultFactory.whitelist(vaultImpl);
+        
+        // Deploy registries
+        l1Registry = new L1Registry(payable(protocolOwner), 0.01 ether, 0.1 ether, protocolOwner);
+        operatorRegistry = new OperatorRegistry();
+        
+        // Deploy opt-in services
+        operatorVaultOptInService = new OperatorVaultOptInService(
+            address(operatorRegistry),
+            address(vaultFactory),
+            "OperatorVaultOptInService"
+        );
+        
+        operatorL1OptInService = new OperatorL1OptInService(
+            address(operatorRegistry),
+            address(l1Registry),
+            "OperatorL1OptInService"
+        );
+        
+        // Whitelist L1RestakeDelegator implementation
+        address l1RestakeDelegatorImpl = address(
+            new L1RestakeDelegator(
+                address(l1Registry),
+                address(vaultFactory),
+                address(operatorVaultOptInService),
+                address(operatorL1OptInService),
+                address(delegatorFactory),
+                delegatorFactory.totalTypes()
+            )
+        );
+        vm.prank(protocolOwner);
+        delegatorFactory.whitelist(l1RestakeDelegatorImpl);
+        
+        // Deploy balancer
+        DeployBalancerValidatorManager deployScript = new DeployBalancerValidatorManager();
+        bytes[] memory migrated = new bytes[](2);
+        migrated[0] = hex"2345678123456781234567812345678123456781";
+        migrated[1] = hex"3456781234567812345678123456781234567812";
+        (balancer,,) = deployScript.run(address(0), uint64(18 ether), migrated);
+        
+        // Transfer balancer ownership to l1Owner
+        address currentOwner = BalancerValidatorManager(balancer).owner();
+        vm.prank(currentOwner);
+        BalancerValidatorManager(balancer).transferOwnership(l1Owner);
+        
+        // Register alice as operator
+        vm.prank(alice);
+        operatorRegistry.registerOperator("alice-metadata");
+        
+        // Fund test accounts
+        vm.deal(alice, 100 ether);
+        vm.deal(bob, 100 ether);
+        vm.deal(staker, 100 ether);
+        vm.deal(l1Owner, 100 ether);
+        
+        // AFTER deploy script finishes, override the canonical warp messenger with our push-style test messenger
+        {
+            MockWarpMessenger messenger = new MockWarpMessenger();
+            vm.etch(WARP, address(messenger).code);
+        }
+        
+        // Deploy the middleware with a standard 18-decimal token as primary
+        uint256 scaleFactor = 10 ** 18;
+        uint256 maxStakeAmount = 1_000 * scaleFactor;
+        uint256 minStakeAmount = 1 * scaleFactor;
+        
+        AvalancheL1MiddlewareSettings memory middlewareSettings = AvalancheL1MiddlewareSettings({
+            balancer: balancer,
+            operatorRegistry: address(operatorRegistry),
+            vaultRegistry: address(vaultFactory),
+            operatorL1Optin: address(operatorL1OptInService),
+            epochDuration: 4 hours,
+            slashingWindow: 5 hours,
+            stakeUpdateWindow: 3 hours
+        });
+        
+        middleware = new AvalancheL1Middleware(
+            middlewareSettings,
+            l1Owner,
+            address(new Token("PrimaryToken")), // dummy primary collateral
+            maxStakeAmount,
+            minStakeAmount,
+            scaleFactor
+        );
+        
+        // Deploy vaultManager
+        vaultManager = new MiddlewareVaultManager(
+            address(vaultFactory), 
+            l1Owner, 
+            address(middleware), 
+            24
+        );
+        
+        // Set the vault manager in the middleware
+        vm.prank(l1Owner);
+        middleware.setVaultManager(address(vaultManager));
+        
+        // Setup middleware as a security module on the Balancer
+        vm.prank(l1Owner);
+        BalancerValidatorManager(balancer).setUpSecurityModule(address(middleware), uint64(1000));
+        
+        // Register L1
+        _registerL1(balancer, address(middleware));
+        
+        // Now alice can opt into the L1 after it's registered
+        vm.prank(alice);
+        operatorL1OptInService.optIn(balancer);
+        
+        // Register operator alice in middleware
+        vm.prank(l1Owner);
+        middleware.registerOperator(alice);
+    }
+    
+    // Helper functions
+    function _optInOperatorVault(address operator, address vault) internal {
+        vm.prank(operator);
+        operatorVaultOptInService.optIn(vault);
+    }
+    
+    function _registerL1(address _l1, address _middleware) internal {
+        address balancerOwner = Ownable(_l1).owner();
+        vm.deal(balancerOwner, 1 ether);
+        vm.prank(balancerOwner);
+        l1Registry.registerL1{value: 0.01 ether}(_l1, _middleware, "metadataURL");
+    }
+    
+    function _pOwner1(address owner) internal pure returns (PChainOwner memory) {
+        address[] memory addresses = new address[](1);
+        addresses[0] = owner;
+        return PChainOwner({
+            threshold: 1,
+            addresses: addresses
+        });
+    }
+    
+    function _ensureFreeStake(address operator) internal view {
+        // Helper function to ensure operator has free stake
+        // In these tests, we don't need to do anything as operators start with free stake
+    }
     /// POC 1: available stake inflation when primary collateral has 6 decimals.
     function test_POC_AvailableStakeInflated_Primary6Decimals() public {
         // --- 6-dec primary token and vault ---
         ERC20WithDecimals usdc6Dec = new ERC20WithDecimals("USDC6", "USDC6", 6);
 
-        uint48 epochDuration = 4 hours;
+        uint48 epochDuration = 8 hours;
         address vImplOwner = bob;
         address vault6DecAddress = vaultFactory.create(
             vaultFactory.lastVersion(),
@@ -136,8 +327,9 @@ contract pocAuditOctane is MiddlewareTestBase {
             BalancerValidatorManager(balancer).setUpSecurityModule(address(middleware6Dec), uint64(2000));
         }
 
-        // Skip L1 registration since balancer is already registered in base setUp
-        // _registerL1(balancer, address(middleware6Dec));
+        // Update the L1's middleware association to the new middleware6Dec
+        vm.prank(l1Owner);
+        l1Registry.setL1Middleware(balancer, address(middleware6Dec));
 
         // Register vault6Dec for class 1 in middleware6Dec
         vm.startPrank(l1Owner);  // vaultManager6Dec is owned by the l1Owner
@@ -160,12 +352,13 @@ contract pocAuditOctane is MiddlewareTestBase {
         vm.warp(middleware6Dec.getEpochStartTs(nextMw6Epoch) + 1);
         middleware6Dec.calcAndCacheNodeStakeForAllOperators();
 
-        // totalStake18 = 1,000e18 while capU = 2,000e6 → available stake becomes 2,000e6 (inflated)
+        // After normalization fix there is no inflation: available == actual stake (1,000e6)
         uint256 availableStake = middleware6Dec.getOperatorAvailableStake(alice);
-        assertEq(availableStake, 2_000 * 10**6, "inflated to module cap in U");
+        assertEq(availableStake, 1_000 * 10**6, "no inflation; equals actual stake");
 
-        // Prove exploitability: add node with 1,500e6 though real vault stake is only 1,000e6
+        // Adding 1,500e6 must now fail (insufficient free stake)
         bytes32 nodeId = keccak256("inflation-node");
+        vm.expectRevert(IAvalancheL1Middleware.AvalancheL1Middleware__InsufficientStake.selector);
         vm.prank(alice);
         middleware6Dec.addNode(
             nodeId,
@@ -174,12 +367,89 @@ contract pocAuditOctane is MiddlewareTestBase {
             _pOwner1(alice),
             1_500 * 10**6
         );
-        // Success proves over-allocation beyond real stake.
+        // Revert proves that over-allocation is prevented.
     }
 
     /// POC 2: secondary min per-node bypass when secondary collateral has 6 decimals.
     function test_POC_MinSecondaryBypass_6Decimals() public {
-        // Secondary token with 6 decimals
+        // First, set up primary collateral (18-dec) so alice has enough primary stake
+        // Use the same primary token that the middleware was initialized with
+        address primaryToken = middleware.PRIMARY_ASSET();
+        
+        // Create primary vault
+        address primaryVaultAddress = vaultFactory.create(
+            vaultFactory.lastVersion(),
+            bob,
+            abi.encode(
+                IVaultTokenized.InitParams({
+                    collateral: primaryToken,
+                    burner: address(0xdEaD),
+                    epochDuration: 8 hours,
+                    depositWhitelist: false,
+                    isDepositLimit: false,
+                    depositLimit: 0,
+                    defaultAdminRoleHolder: bob,
+                    depositWhitelistSetRoleHolder: bob,
+                    depositorWhitelistRoleHolder: bob,
+                    isDepositLimitSetRoleHolder: bob,
+                    depositLimitSetRoleHolder: bob,
+                    name: "Primary Vault",
+                    symbol: "PRIMV"
+                })
+            ),
+            address(delegatorFactory),
+            address(slasherFactory)
+        );
+        VaultTokenized primaryVault = VaultTokenized(primaryVaultAddress);
+        
+        // Create delegator for primary vault
+        address[] memory primaryL1LimitSetRoleHolders = new address[](1);
+        primaryL1LimitSetRoleHolders[0] = bob;
+        address[] memory primaryOperatorL1SharesSetRoleHolders = new address[](1);
+        primaryOperatorL1SharesSetRoleHolders[0] = bob;
+        
+        address primaryDelegatorAddress = delegatorFactory.create(
+            0,
+            abi.encode(
+                primaryVaultAddress,
+                abi.encode(
+                    IL1RestakeDelegator.InitParams({
+                        baseParams: IBaseDelegator.BaseParams({
+                            defaultAdminRoleHolder: bob,
+                            hook: address(0),
+                            hookSetRoleHolder: bob
+                        }),
+                        l1LimitSetRoleHolders: primaryL1LimitSetRoleHolders,
+                        operatorL1SharesSetRoleHolders: primaryOperatorL1SharesSetRoleHolders
+                    })
+                )
+            )
+        );
+        L1RestakeDelegator primaryDelegator = L1RestakeDelegator(primaryDelegatorAddress);
+        
+        vm.prank(bob);
+        primaryVault.setDelegator(primaryDelegatorAddress);
+        
+        // Alice opts into primary vault
+        _optInOperatorVault(alice, primaryVaultAddress);
+        
+        // Register primary vault with vaultManager
+        vm.prank(l1Owner);
+        vaultManager.registerVault(primaryVaultAddress, 1, 1000 ether);
+        
+        // Deposit primary tokens and assign to alice
+        Token(primaryToken).transfer(staker, 2 ether);
+        vm.startPrank(staker);
+        Token(primaryToken).approve(primaryVaultAddress, 2 ether);
+        (uint256 primaryDepositUsed, uint256 primaryMintedShares) = primaryVault.deposit(staker, 2 ether);
+        vm.stopPrank();
+        
+        vm.startPrank(bob);
+        primaryDelegator.setL1Limit(balancer, 1, 1000 ether);
+        primaryDelegator.setOperatorL1Shares(balancer, 1, alice, primaryMintedShares);
+        vm.stopPrank();
+        
+        // Now set up secondary token with 6 decimals
         ERC20WithDecimals usdc6Dec = new ERC20WithDecimals("USDC6", "USDC6", 6);
 
         // Create vault for secondary class
@@ -263,24 +533,33 @@ contract pocAuditOctane is MiddlewareTestBase {
         delegatorUSDC.setOperatorL1Shares(balancer, secClass, alice, shares);
         vm.stopPrank();
 
-        // Advance one epoch so the newly registered secondary vault counts this epoch
+        // Advance one epoch so the newly registered vaults count this epoch
         {
             uint48 nextEpoch = middleware.getCurrentEpoch() + 1;
             vm.warp(middleware.getEpochStartTs(nextEpoch) + 1);
         }
         middleware.calcAndCacheNodeStakeForAllOperators();
-        _ensureFreeStake(alice);
 
-        // Try to add a node; should FAIL if units matched, but succeeds due to 18-dec vs U mix
+        // Sanity assertions to clearly show the stake situation
+        uint48 e = middleware.getCurrentEpoch();
+        // Stakes for class 42 are reported in its canonical unit (USDC6 => 6 decimals)
+        assertEq(middleware.getOperatorStake(alice, e, 42), 50 * 10**6, "Alice has only 50 USDC");
+        assertGe(middleware.getOperatorStake(alice, e, 1), 1 ether, "Alice has enough primary stake");
+
+        // Try to add a node with minimum primary stake (1 ether)
+        // Alice has 2 ether primary stake (sufficient) 
+        // But only 50 USDC secondary stake (insufficient - needs 100 USDC minimum)
+        // With only 50 USDC (min=100), this must now revert
         bytes32 nodeId = keccak256("secondary-bypass-node");
+        vm.expectRevert(IAvalancheL1Middleware.AvalancheL1Middleware__InsufficientStake.selector);
         vm.prank(alice);
         middleware.addNode(
             nodeId,
             new bytes(48),
             _pOwner1(alice),
             _pOwner1(alice),
-            0 // will use min primary internally; secondary check should gate but doesn't
+            1 ether // use minimum primary stake
         );
-        // Success proves min-secondary bypass with 6-dec class.
+        // Revert proves min-secondary is now properly enforced.
     }
 }

--- a/test/middleware/pocAuditOctane.t.sol
+++ b/test/middleware/pocAuditOctane.t.sol
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {MiddlewareTestBase} from "./MiddlewareTestBase.t.sol";
+
+import {AvalancheL1Middleware, AvalancheL1MiddlewareSettings} from
+    "../../src/contracts/middleware/AvalancheL1Middleware.sol";
+import {MiddlewareVaultManager} from "../../src/contracts/middleware/MiddlewareVaultManager.sol";
+import {VaultTokenized} from "../../src/contracts/vault/VaultTokenized.sol";
+import {L1RestakeDelegator} from "../../src/contracts/delegator/L1RestakeDelegator.sol";
+import {IVaultTokenized} from "../../src/interfaces/vault/IVaultTokenized.sol";
+import {IBaseDelegator} from "../../src/interfaces/delegator/IBaseDelegator.sol";
+import {IL1RestakeDelegator} from "../../src/interfaces/delegator/IL1RestakeDelegator.sol";
+import {IBalancerValidatorManager} from
+    "@suzaku/contracts-library/interfaces/ValidatorManager/IBalancerValidatorManager.sol";
+import {BalancerValidatorManager} from
+    "@suzaku/contracts-library/contracts/ValidatorManager/BalancerValidatorManager.sol";
+
+import {ERC20WithDecimals} from "../mocks/MockERC20WithDecimals.sol";
+import {Time} from "@openzeppelin/contracts/utils/types/Time.sol";
+
+contract pocAuditOctane is MiddlewareTestBase {
+    /// POC 1: available stake inflation when primary collateral has 6 decimals.
+    function test_POC_AvailableStakeInflated_Primary6Decimals() public {
+        // --- 6-dec primary token and vault ---
+        ERC20WithDecimals usdc6Dec = new ERC20WithDecimals("USDC6", "USDC6", 6);
+
+        uint48 epochDuration = 4 hours;
+        address vImplOwner = bob;
+        address vault6DecAddress = vaultFactory.create(
+            vaultFactory.lastVersion(),
+            vImplOwner,
+            abi.encode(
+                IVaultTokenized.InitParams({
+                    collateral: address(usdc6Dec),
+                    burner: address(0xdEaD),
+                    epochDuration: epochDuration,
+                    depositWhitelist: false,
+                    isDepositLimit: false,
+                    depositLimit: 0,
+                    defaultAdminRoleHolder: bob,
+                    depositWhitelistSetRoleHolder: bob,
+                    depositorWhitelistRoleHolder: bob,
+                    isDepositLimitSetRoleHolder: bob,
+                    depositLimitSetRoleHolder: bob,
+                    name: "USDC6 Vault",
+                    symbol: "USDC6V"
+                })
+            ),
+            address(delegatorFactory),
+            address(slasherFactory)
+        );
+        VaultTokenized vault6Dec = VaultTokenized(vault6DecAddress);
+
+        // Delegator for vault6
+        address[] memory l1LimitSetRoleHolders = new address[](1);
+        l1LimitSetRoleHolders[0] = bob;
+        address[] memory operatorL1SharesSetRoleHolders = new address[](1);
+        operatorL1SharesSetRoleHolders[0] = bob;
+
+        address delegator6DecAddress = delegatorFactory.create(
+            0,
+            abi.encode(
+                vault6DecAddress,
+                abi.encode(
+                    IL1RestakeDelegator.InitParams({
+                        baseParams: IBaseDelegator.BaseParams({
+                            defaultAdminRoleHolder: bob,
+                            hook: address(0),
+                            hookSetRoleHolder: bob
+                        }),
+                        l1LimitSetRoleHolders: l1LimitSetRoleHolders,
+                        operatorL1SharesSetRoleHolders: operatorL1SharesSetRoleHolders
+                    })
+                )
+            )
+        );
+        L1RestakeDelegator delegator6Dec = L1RestakeDelegator(delegator6DecAddress);
+
+        vm.prank(bob);
+        vault6Dec.setDelegator(delegator6DecAddress);
+
+        // Operator opt-ins for this new vault
+        _optInOperatorVault(alice, vault6DecAddress);
+
+        // Deposit 1,000 units (U = 6 decimals)
+        uint256 depositAmount = 1_000 * 10**6;
+        usdc6Dec.transfer(staker, depositAmount);
+        vm.startPrank(staker);
+        usdc6Dec.approve(vault6DecAddress, depositAmount);
+        (uint256 depositUsed, uint256 mintedShares) = vault6Dec.deposit(staker, depositAmount);
+        vm.stopPrank();
+        assertEq(depositUsed, depositAmount);
+
+        // L1 limit ≥ deposit
+        // _setL1Limit(bob, balancer, 1, 5_000 * 10**6, delegator6Dec);
+        // _setOperatorL1Shares(bob, balancer, 1, alice, mintedShares, delegator6Dec);
+        // NOTE: don't set L1 limit yet (maxL1Limit must be set by middleware via registerVault)
+
+        // --- New middleware with 6-dec primary ---
+        AvalancheL1MiddlewareSettings memory middlewareSettings = AvalancheL1MiddlewareSettings({
+            balancer: balancer,
+            operatorRegistry: address(operatorRegistry),
+            vaultRegistry: address(vaultFactory),
+            operatorL1Optin: address(operatorL1OptInService),
+            epochDuration: 4 hours,
+            slashingWindow: 5 hours,
+            stakeUpdateWindow: 3 hours
+        });
+
+        // scaleFactor in U; require scaleFactor ≤ minStake in constructor
+        uint256 minStakeAmount = 1_000_000; // 1 token
+        uint256 maxStakeAmount = 1_000_000_000_000_000; // large
+        uint256 scaleFactor = 1_000_000; // 1e6
+
+        AvalancheL1Middleware middleware6Dec = new AvalancheL1Middleware(
+            middlewareSettings,
+            l1Owner,  // l1Owner owns middleware
+            address(usdc6Dec),
+            maxStakeAmount,
+            minStakeAmount,
+            scaleFactor
+        );
+
+        // Vault manager for middleware6Dec
+        MiddlewareVaultManager vaultManager6Dec = new MiddlewareVaultManager(address(vaultFactory), l1Owner, address(middleware6Dec), 24);
+        vm.prank(l1Owner);
+        middleware6Dec.setVaultManager(address(vaultManager6Dec));
+
+        // Keep middleware and vaultManager owned by the l1Owner
+        // Do NOT transfer ownership to anyone else as per the new architecture
+
+        // Register middleware6Dec as a security module with **maxWeight = 2000** → capU = 2000 * scaleFactor = 2,000e6
+        {
+            vm.prank(l1Owner);
+            BalancerValidatorManager(balancer).setUpSecurityModule(address(middleware6Dec), uint64(2000));
+        }
+
+        // Skip L1 registration since balancer is already registered in base setUp
+        // _registerL1(balancer, address(middleware6Dec));
+
+        // Register vault6Dec for class 1 in middleware6Dec
+        vm.startPrank(l1Owner);  // vaultManager6Dec is owned by the l1Owner
+        vaultManager6Dec.registerVault(vault6DecAddress, 1, 10_000 * 10**6);
+        vm.stopPrank();
+
+        // Register operator in middleware6Dec
+        vm.startPrank(l1Owner);  // middleware6Dec is owned by the l1Owner
+        middleware6Dec.registerOperator(alice);
+        vm.stopPrank();
+
+        // Now that maxL1Limit is set by registerVault, set per‑L1 limit & shares on delegator
+        // bob is the delegator owner (defaultAdminRoleHolder), so he can set limits
+        vm.startPrank(bob);
+        delegator6Dec.setL1Limit(balancer, 1, 5_000 * 10**6);
+        delegator6Dec.setOperatorL1Shares(balancer, 1, alice, mintedShares);
+        vm.stopPrank();
+        // Move to next middleware6Dec epoch so vault/operator are active for stake accounting
+        uint48 nextMw6Epoch = middleware6Dec.getCurrentEpoch() + 1;
+        vm.warp(middleware6Dec.getEpochStartTs(nextMw6Epoch) + 1);
+        middleware6Dec.calcAndCacheNodeStakeForAllOperators();
+
+        // totalStake18 = 1,000e18 while capU = 2,000e6 → available stake becomes 2,000e6 (inflated)
+        uint256 availableStake = middleware6Dec.getOperatorAvailableStake(alice);
+        assertEq(availableStake, 2_000 * 10**6, "inflated to module cap in U");
+
+        // Prove exploitability: add node with 1,500e6 though real vault stake is only 1,000e6
+        bytes32 nodeId = keccak256("inflation-node");
+        vm.prank(alice);
+        middleware6Dec.addNode(
+            nodeId,
+            new bytes(48),
+            _pOwner1(alice),
+            _pOwner1(alice),
+            1_500 * 10**6
+        );
+        // Success proves over-allocation beyond real stake.
+    }
+
+    /// POC 2: secondary min per-node bypass when secondary collateral has 6 decimals.
+    function test_POC_MinSecondaryBypass_6Decimals() public {
+        // Secondary token with 6 decimals
+        ERC20WithDecimals usdc6Dec = new ERC20WithDecimals("USDC6", "USDC6", 6);
+
+        // Create vault for secondary class
+        address vaultUSDCAddress = vaultFactory.create(
+            vaultFactory.lastVersion(),
+            bob,
+            abi.encode(
+                IVaultTokenized.InitParams({
+                    collateral: address(usdc6Dec),
+                    burner: address(0xdEaD),
+                    epochDuration: 8 hours,
+                    depositWhitelist: false,
+                    isDepositLimit: false,
+                    depositLimit: 0,
+                    defaultAdminRoleHolder: bob,
+                    depositWhitelistSetRoleHolder: bob,
+                    depositorWhitelistRoleHolder: bob,
+                    isDepositLimitSetRoleHolder: bob,
+                    depositLimitSetRoleHolder: bob,
+                    name: "USDC6 Sec",
+                    symbol: "USDC6S"
+                })
+            ),
+            address(delegatorFactory),
+            address(slasherFactory)
+        );
+        VaultTokenized vaultUSDC6Dec = VaultTokenized(vaultUSDCAddress);
+
+        // Delegator for secondary vault
+        address[] memory l1LimitSetRoleHolders = new address[](1);
+        l1LimitSetRoleHolders[0] = bob;
+        address[] memory operatorL1SharesSetRoleHolders = new address[](1);
+        operatorL1SharesSetRoleHolders[0] = bob;
+
+        address delegatorUSDCAddress = delegatorFactory.create(
+            0,
+            abi.encode(
+                vaultUSDCAddress,
+                abi.encode(
+                    IL1RestakeDelegator.InitParams({
+                        baseParams: IBaseDelegator.BaseParams({
+                            defaultAdminRoleHolder: bob,
+                            hook: address(0),
+                            hookSetRoleHolder: bob
+                        }),
+                        l1LimitSetRoleHolders: l1LimitSetRoleHolders,
+                        operatorL1SharesSetRoleHolders: operatorL1SharesSetRoleHolders
+                    })
+                )
+            )
+        );
+        L1RestakeDelegator delegatorUSDC = L1RestakeDelegator(delegatorUSDCAddress);
+
+        vm.prank(bob);
+        vaultUSDC6Dec.setDelegator(delegatorUSDCAddress);
+
+        // Add secondary class with min per-node = 100 USDC (U = 100e6)
+        uint96 secClass = 42;
+        vm.startPrank(l1Owner);
+        middleware.addCollateralClass(secClass, 100 * 10**6, 0, address(usdc6Dec));
+        middleware.activateSecondaryCollateralClass(secClass);
+        // Register the vault in that class
+        vaultManager.registerVault(vaultUSDCAddress, secClass, 10_000 * 10**6);
+        vm.stopPrank();
+
+        // Opt-in operator to this vault
+        _optInOperatorVault(alice, vaultUSDCAddress);
+
+        // Give Alice only 50 USDC (insufficient) but bug will pass
+        uint256 depositAmount = 50 * 10**6;
+        usdc6Dec.transfer(staker, depositAmount);
+        vm.startPrank(staker);
+        usdc6Dec.approve(vaultUSDCAddress, depositAmount);
+        (uint256 depositUsed, uint256 shares) = vaultUSDC6Dec.deposit(staker, depositAmount);
+        vm.stopPrank();
+        assertEq(depositUsed, depositAmount);
+
+        // bob is the delegator owner (defaultAdminRoleHolder), so he can set limits
+        vm.startPrank(bob);
+        delegatorUSDC.setL1Limit(balancer, secClass, 1_000 * 10**6);
+        delegatorUSDC.setOperatorL1Shares(balancer, secClass, alice, shares);
+        vm.stopPrank();
+
+        // Advance one epoch so the newly registered secondary vault counts this epoch
+        {
+            uint48 nextEpoch = middleware.getCurrentEpoch() + 1;
+            vm.warp(middleware.getEpochStartTs(nextEpoch) + 1);
+        }
+        middleware.calcAndCacheNodeStakeForAllOperators();
+        _ensureFreeStake(alice);
+
+        // Try to add a node; should FAIL if units matched, but succeeds due to 18-dec vs U mix
+        bytes32 nodeId = keccak256("secondary-bypass-node");
+        vm.prank(alice);
+        middleware.addNode(
+            nodeId,
+            new bytes(48),
+            _pOwner1(alice),
+            _pOwner1(alice),
+            0 // will use min primary internally; secondary check should gate but doesn't
+        );
+        // Success proves min-secondary bypass with 6-dec class.
+    }
+}

--- a/test/middleware/pocAuditOctane.t.sol
+++ b/test/middleware/pocAuditOctane.t.sol
@@ -18,6 +18,7 @@ import {BalancerValidatorManager} from
     "@suzaku/contracts-library/contracts/ValidatorManager/BalancerValidatorManager.sol";
 
 import {ERC20WithDecimals} from "../mocks/MockERC20WithDecimals.sol";
+import {ICollateralClassRegistry} from "../../src/interfaces/middleware/ICollateralClassRegistry.sol";
 import {Time} from "@openzeppelin/contracts/utils/types/Time.sol";
 
 // Additional imports needed for standalone test
@@ -561,5 +562,472 @@ contract pocAuditOctane is Test {
             1 ether // use minimum primary stake
         );
         // Revert proves min-secondary is now properly enforced.
+    }
+
+    /// Primary = 18d (from setUp). Adding a 6d asset to primary class must revert.
+    function test_Primary18_AddSecondAsset6Decimals_Revert() public {
+        ERC20WithDecimals six = new ERC20WithDecimals("SIX", "SIX", 6);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ICollateralClassRegistry.CollateralClassRegistry__AssetDecimalsMismatch.selector,
+                uint8(18),
+                uint8(6)
+            )
+        );
+        vm.prank(l1Owner);
+        middleware.addAssetToClass(1, address(six));
+    }
+
+    /// Spin up a new middleware with 6d primary; same‑dec asset is allowed, different‑dec (8d) must revert.
+    function test_Primary6_AddSecondAsset8Decimals_Revert_SameDecPass() public {
+        ERC20WithDecimals token6 = new ERC20WithDecimals("USDC6", "U6", 6);
+        AvalancheL1MiddlewareSettings memory settings = AvalancheL1MiddlewareSettings({
+            balancer: balancer,
+            operatorRegistry: address(operatorRegistry),
+            vaultRegistry: address(vaultFactory),
+            operatorL1Optin: address(operatorL1OptInService),
+            epochDuration: 4 hours,
+            slashingWindow: 5 hours,
+            stakeUpdateWindow: 3 hours
+        });
+        uint256 minStake = 1_000_000; // 1e6
+        uint256 maxStake = 1_000_000_000_000_000;
+        uint256 scale    = 1_000_000;
+
+        AvalancheL1Middleware mw6 = new AvalancheL1Middleware(
+            settings, l1Owner, address(token6), maxStake, minStake, scale
+        );
+        MiddlewareVaultManager vm6 = new MiddlewareVaultManager(address(vaultFactory), l1Owner, address(mw6), 24);
+        vm.prank(l1Owner);
+        mw6.setVaultManager(address(vm6));
+
+        // same‑dec (6) → ok
+        ERC20WithDecimals another6 = new ERC20WithDecimals("MOCK6", "M6", 6);
+        vm.prank(l1Owner);
+        mw6.addAssetToClass(1, address(another6));
+
+        // different‑dec (8) → revert
+        ERC20WithDecimals tok8 = new ERC20WithDecimals("TOK8","T8",8);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ICollateralClassRegistry.CollateralClassRegistry__AssetDecimalsMismatch.selector,
+                uint8(6),
+                uint8(8)
+            )
+        );
+        vm.prank(l1Owner);
+        mw6.addAssetToClass(1, address(tok8));
+    }
+
+    /// Secondary class with 8 decimals: adding another 8d asset is OK; adding 6d must revert.
+    function test_Secondary8_AddSameDecPass_DiffDecRevert() public {
+        ERC20WithDecimals a8 = new ERC20WithDecimals("A8","A8",8);
+        ERC20WithDecimals b8 = new ERC20WithDecimals("B8","B8",8);
+        ERC20WithDecimals c6 = new ERC20WithDecimals("C6","C6",6);
+        uint96 sec = 88;
+
+        vm.startPrank(l1Owner);
+        middleware.addCollateralClass(sec, 0, 0, address(a8));
+        middleware.activateSecondaryCollateralClass(sec);
+
+        // same dec ok
+        middleware.addAssetToClass(sec, address(b8));
+
+        // different dec revert
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ICollateralClassRegistry.CollateralClassRegistry__AssetDecimalsMismatch.selector,
+                uint8(8),
+                uint8(6)
+            )
+        );
+        middleware.addAssetToClass(sec, address(c6));
+        vm.stopPrank();
+    }
+
+    /// Secondary in-use protections: cannot deactivate class or remove asset while a vault uses it.
+    function test_Secondary8_InUse_DeactivateOrRemove_Revert() public {
+        ERC20WithDecimals t8 = new ERC20WithDecimals("T8","T8",8);
+        uint96 sec = 77;
+
+        // create class + activate
+        vm.startPrank(l1Owner);
+        middleware.addCollateralClass(sec, 0, 0, address(t8));
+        middleware.activateSecondaryCollateralClass(sec);
+        vm.stopPrank();
+
+        // register a vault for that class
+        address vAddr = vaultFactory.create(
+            vaultFactory.lastVersion(),
+            bob,
+            abi.encode(
+                IVaultTokenized.InitParams({
+                    collateral: address(t8),
+                    burner: address(0xdEaD),
+                    epochDuration: 8 hours,
+                    depositWhitelist: false,
+                    isDepositLimit: false,
+                    depositLimit: 0,
+                    defaultAdminRoleHolder: bob,
+                    depositWhitelistSetRoleHolder: bob,
+                    depositorWhitelistRoleHolder: bob,
+                    isDepositLimitSetRoleHolder: bob,
+                    depositLimitSetRoleHolder: bob,
+                    name: "SEC8",
+                    symbol: "S8"
+                })
+            ),
+            address(delegatorFactory),
+            address(slasherFactory)
+        );
+        VaultTokenized v = VaultTokenized(vAddr);
+
+        address dAddr = delegatorFactory.create(
+            0,
+            abi.encode(
+                vAddr,
+                abi.encode(
+                    IL1RestakeDelegator.InitParams({
+                        baseParams: IBaseDelegator.BaseParams({
+                            defaultAdminRoleHolder: bob,
+                            hook: address(0),
+                            hookSetRoleHolder: bob
+                        }),
+                        l1LimitSetRoleHolders: _one(bob),
+                        operatorL1SharesSetRoleHolders: _one(bob)
+                    })
+                )
+            )
+        );
+        vm.prank(bob);
+        v.setDelegator(dAddr);
+
+        vm.prank(l1Owner);
+        vaultManager.registerVault(vAddr, sec, 1_000 * 10**8);
+
+        // cannot deactivate while in use
+        vm.expectRevert(
+            abi.encodeWithSelector(IAvalancheL1Middleware.AvalancheL1Middleware__AssetStillInUse.selector, sec)
+        );
+        vm.prank(l1Owner);
+        middleware.deactivateSecondaryCollateralClass(sec);
+
+        // cannot remove the only asset while in use
+        vm.expectRevert(
+            abi.encodeWithSelector(IAvalancheL1Middleware.AvalancheL1Middleware__AssetStillInUse.selector, sec)
+        );
+        vm.prank(l1Owner);
+        middleware.removeAssetFromClass(sec, address(t8));
+    }
+
+    /// Helper for delegator role arrays
+    function _one(address a) internal pure returns (address[] memory arr) {
+        arr = new address[](1);
+        arr[0] = a;
+    }
+
+    /// POC variant: secondary = 8 decimals. Min per-node enforced during addNode.
+    function test_POC_MinSecondaryBypass_8Decimals() public {
+        // Ensure primary stake for alice (same as POC_6d but with current middleware/primary 18d)
+        address primaryToken = middleware.PRIMARY_ASSET();
+
+        // primary vault + delegator + deposit 2e18 assigned to alice
+        address pVaultAddr = vaultFactory.create(
+            vaultFactory.lastVersion(),
+            bob,
+            abi.encode(
+                IVaultTokenized.InitParams({
+                    collateral: primaryToken,
+                    burner: address(0xdEaD),
+                    epochDuration: 8 hours,
+                    depositWhitelist: false,
+                    isDepositLimit: false,
+                    depositLimit: 0,
+                    defaultAdminRoleHolder: bob,
+                    depositWhitelistSetRoleHolder: bob,
+                    depositorWhitelistRoleHolder: bob,
+                    isDepositLimitSetRoleHolder: bob,
+                    depositLimitSetRoleHolder: bob,
+                    name: "PRIM",
+                    symbol: "P"
+                })
+            ),
+            address(delegatorFactory),
+            address(slasherFactory)
+        );
+        VaultTokenized pVault = VaultTokenized(pVaultAddr);
+
+        address pDelAddr = delegatorFactory.create(
+            0,
+            abi.encode(
+                pVaultAddr,
+                abi.encode(
+                    IL1RestakeDelegator.InitParams({
+                        baseParams: IBaseDelegator.BaseParams({
+                            defaultAdminRoleHolder: bob,
+                            hook: address(0),
+                            hookSetRoleHolder: bob
+                        }),
+                        l1LimitSetRoleHolders: _one(bob),
+                        operatorL1SharesSetRoleHolders: _one(bob)
+                    })
+                )
+            )
+        );
+        L1RestakeDelegator pDel = L1RestakeDelegator(pDelAddr);
+        vm.prank(bob);
+        pVault.setDelegator(pDelAddr);
+
+        _optInOperatorVault(alice, pVaultAddr);
+        vm.prank(l1Owner);
+        vaultManager.registerVault(pVaultAddr, 1, 1_000 ether);
+
+        Token(primaryToken).transfer(staker, 2 ether);
+        vm.startPrank(staker);
+        Token(primaryToken).approve(pVaultAddr, 2 ether);
+        ( , uint256 pShares) = pVault.deposit(staker, 2 ether);
+        vm.stopPrank();
+
+        vm.startPrank(bob);
+        pDel.setL1Limit(balancer, 1, 1_000 ether);
+        pDel.setOperatorL1Shares(balancer, 1, alice, pShares);
+        vm.stopPrank();
+
+        // secondary 8d
+        ERC20WithDecimals t8 = new ERC20WithDecimals("USDT8", "U8", 8);
+        uint96 sec = 66;
+
+        // class with min per-node = 100e8
+        vm.startPrank(l1Owner);
+        middleware.addCollateralClass(sec, 100 * 10**8, 0, address(t8));
+        middleware.activateSecondaryCollateralClass(sec);
+        vm.stopPrank();
+
+        // vault + delegator for secondary
+        address sVaultAddr = vaultFactory.create(
+            vaultFactory.lastVersion(),
+            bob,
+            abi.encode(
+                IVaultTokenized.InitParams({
+                    collateral: address(t8),
+                    burner: address(0xdEaD),
+                    epochDuration: 8 hours,
+                    depositWhitelist: false,
+                    isDepositLimit: false,
+                    depositLimit: 0,
+                    defaultAdminRoleHolder: bob,
+                    depositWhitelistSetRoleHolder: bob,
+                    depositorWhitelistRoleHolder: bob,
+                    isDepositLimitSetRoleHolder: bob,
+                    depositLimitSetRoleHolder: bob,
+                    name: "SEC8",
+                    symbol: "S8"
+                })
+            ),
+            address(delegatorFactory),
+            address(slasherFactory)
+        );
+        VaultTokenized sVault = VaultTokenized(sVaultAddr);
+
+        address sDelAddr = delegatorFactory.create(
+            0,
+            abi.encode(
+                sVaultAddr,
+                abi.encode(
+                    IL1RestakeDelegator.InitParams({
+                        baseParams: IBaseDelegator.BaseParams({
+                            defaultAdminRoleHolder: bob,
+                            hook: address(0),
+                            hookSetRoleHolder: bob
+                        }),
+                        l1LimitSetRoleHolders: _one(bob),
+                        operatorL1SharesSetRoleHolders: _one(bob)
+                    })
+                )
+            )
+        );
+        L1RestakeDelegator sDel = L1RestakeDelegator(sDelAddr);
+        vm.prank(bob);
+        sVault.setDelegator(sDelAddr);
+
+        _optInOperatorVault(alice, sVaultAddr);
+        vm.prank(l1Owner);
+        vaultManager.registerVault(sVaultAddr, sec, 10_000 * 10**8);
+
+        // Give only 50e8 (insufficient vs 100e8/node)
+        uint256 dep = 50 * 10**8;
+        t8.transfer(staker, dep);
+        vm.startPrank(staker);
+        t8.approve(sVaultAddr, dep);
+        ( , uint256 sShares) = sVault.deposit(staker, dep);
+        vm.stopPrank();
+
+        vm.startPrank(bob);
+        sDel.setL1Limit(balancer, sec, 1_000 * 10**8);
+        sDel.setOperatorL1Shares(balancer, sec, alice, sShares);
+        vm.stopPrank();
+
+        // Advance to next epoch for accounting
+        {
+            uint48 nextEpoch = middleware.getCurrentEpoch() + 1;
+            vm.warp(middleware.getEpochStartTs(nextEpoch) + 1);
+        }
+        middleware.calcAndCacheNodeStakeForAllOperators();
+
+        // Sanity checks
+        uint48 e = middleware.getCurrentEpoch();
+        assertEq(middleware.getOperatorStake(alice, e, sec), 50 * 10**8, "secondary stake is 50e8");
+        assertGe(middleware.getOperatorStake(alice, e, 1), 1 ether, "primary enough");
+
+        // Adding a node should fail due to min secondary per-node
+        bytes32 nodeId = keccak256("sec8-bypass");
+        vm.expectRevert(IAvalancheL1Middleware.AvalancheL1Middleware__InsufficientStake.selector);
+        vm.prank(alice);
+        middleware.addNode(
+            nodeId,
+            new bytes(48),
+            _pOwner1(alice),
+            _pOwner1(alice),
+            1 ether
+        );
+    }
+
+    /// Aggregation across two 8‑dec secondary vaults (same class): sums exactly in class unit.
+    function test_Secondary8_TwoVaults_Aggregation() public {
+        ERC20WithDecimals a8 = new ERC20WithDecimals("A8","A8",8);
+        ERC20WithDecimals b8 = new ERC20WithDecimals("B8","B8",8);
+        uint96 sec = 99;
+
+        vm.startPrank(l1Owner);
+        middleware.addCollateralClass(sec, 0, 0, address(a8));
+        middleware.activateSecondaryCollateralClass(sec);
+        middleware.addAssetToClass(sec, address(b8));
+        vm.stopPrank();
+
+        // Vault A
+        address vA = vaultFactory.create(
+            vaultFactory.lastVersion(),
+            bob,
+            abi.encode(
+                IVaultTokenized.InitParams({
+                    collateral: address(a8),
+                    burner: address(0xdEaD),
+                    epochDuration: 8 hours,
+                    depositWhitelist: false,
+                    isDepositLimit: false,
+                    depositLimit: 0,
+                    defaultAdminRoleHolder: bob,
+                    depositWhitelistSetRoleHolder: bob,
+                    depositorWhitelistRoleHolder: bob,
+                    isDepositLimitSetRoleHolder: bob,
+                    depositLimitSetRoleHolder: bob,
+                    name: "A8V",
+                    symbol: "A8V"
+                })
+            ),
+            address(delegatorFactory),
+            address(slasherFactory)
+        );
+        VaultTokenized VA = VaultTokenized(vA);
+        address dA = delegatorFactory.create(
+            0,
+            abi.encode(
+                vA,
+                abi.encode(
+                    IL1RestakeDelegator.InitParams({
+                        baseParams: IBaseDelegator.BaseParams({
+                            defaultAdminRoleHolder: bob,
+                            hook: address(0),
+                            hookSetRoleHolder: bob
+                        }),
+                        l1LimitSetRoleHolders: _one(bob),
+                        operatorL1SharesSetRoleHolders: _one(bob)
+                    })
+                )
+            )
+        );
+        vm.prank(bob); VA.setDelegator(dA);
+        _optInOperatorVault(alice, vA);
+        vm.prank(l1Owner); vaultManager.registerVault(vA, sec, 10_000 * 10**8);
+
+        // Vault B
+        address vB = vaultFactory.create(
+            vaultFactory.lastVersion(),
+            bob,
+            abi.encode(
+                IVaultTokenized.InitParams({
+                    collateral: address(b8),
+                    burner: address(0xdEaD),
+                    epochDuration: 8 hours,
+                    depositWhitelist: false,
+                    isDepositLimit: false,
+                    depositLimit: 0,
+                    defaultAdminRoleHolder: bob,
+                    depositWhitelistSetRoleHolder: bob,
+                    depositorWhitelistRoleHolder: bob,
+                    isDepositLimitSetRoleHolder: bob,
+                    depositLimitSetRoleHolder: bob,
+                    name: "B8V",
+                    symbol: "B8V"
+                })
+            ),
+            address(delegatorFactory),
+            address(slasherFactory)
+        );
+        VaultTokenized VB = VaultTokenized(vB);
+        address dB = delegatorFactory.create(
+            0,
+            abi.encode(
+                vB,
+                abi.encode(
+                    IL1RestakeDelegator.InitParams({
+                        baseParams: IBaseDelegator.BaseParams({
+                            defaultAdminRoleHolder: bob,
+                            hook: address(0),
+                            hookSetRoleHolder: bob
+                        }),
+                        l1LimitSetRoleHolders: _one(bob),
+                        operatorL1SharesSetRoleHolders: _one(bob)
+                    })
+                )
+            )
+        );
+        vm.prank(bob); VB.setDelegator(dB);
+        _optInOperatorVault(alice, vB);
+        vm.prank(l1Owner); vaultManager.registerVault(vB, sec, 10_000 * 10**8);
+
+        // Deposits: 60e8 + 40e8
+        uint256 depA = 60 * 10**8;
+        uint256 depB = 40 * 10**8;
+
+        a8.transfer(staker, depA);
+        vm.startPrank(staker);
+        a8.approve(vA, depA);
+        ( , uint256 shA) = VA.deposit(staker, depA);
+        vm.stopPrank();
+
+        b8.transfer(staker, depB);
+        vm.startPrank(staker);
+        b8.approve(vB, depB);
+        ( , uint256 shB) = VB.deposit(staker, depB);
+        vm.stopPrank();
+
+        vm.startPrank(bob);
+        L1RestakeDelegator(dA).setL1Limit(balancer, sec, 10_000 * 10**8);
+        L1RestakeDelegator(dA).setOperatorL1Shares(balancer, sec, alice, shA);
+        L1RestakeDelegator(dB).setL1Limit(balancer, sec, 10_000 * 10**8);
+        L1RestakeDelegator(dB).setOperatorL1Shares(balancer, sec, alice, shB);
+        vm.stopPrank();
+
+        // next epoch + cache
+        {
+            uint48 nextEpoch = middleware.getCurrentEpoch() + 1;
+            vm.warp(middleware.getEpochStartTs(nextEpoch) + 1);
+        }
+        middleware.calcAndCacheNodeStakeForAllOperators();
+
+        uint48 e = middleware.getCurrentEpoch();
+        assertEq(middleware.getOperatorStake(alice, e, sec), (depA + depB), "sum in class unit (8d)");
     }
 }

--- a/test/mocks/MockAvalancheL1Middleware.sol
+++ b/test/mocks/MockAvalancheL1Middleware.sol
@@ -7,7 +7,7 @@ contract MockAvalancheL1Middleware {
     uint48 public constant EPOCH_DURATION = 4 hours;
     uint48 public constant SLASHING_WINDOW = 5 hours;
     uint48 public constant REMOVAL_DELAY_EPOCHS = 6;
-    address public immutable L1_VALIDATOR_MANAGER;
+    address public immutable BALANCER;
     address public immutable VAULT_MANAGER;
 
     mapping(uint48 => mapping(bytes32 => uint256)) public nodeStake;
@@ -39,7 +39,7 @@ contract MockAvalancheL1Middleware {
         require(operatorCount > 0, "At least one operator required");
         require(operatorCount == nodesPerOperator.length, "Arrays length mismatch");
 
-        L1_VALIDATOR_MANAGER = balancerValidatorManager;
+        BALANCER = balancerValidatorManager;
         VAULT_MANAGER = vaultManager;
 
         // Generate operators

--- a/test/mocks/MockVaultManager.sol
+++ b/test/mocks/MockVaultManager.sol
@@ -161,7 +161,7 @@ contract MockVaultManager is Ownable {
         //     );
         // }
         // address delegator = IVaultTokenized(vault).delegator();
-        // BaseDelegator(delegator).setMaxL1Limit(middleware.L1_VALIDATOR_MANAGER(), collateralClassId, amount);
+        // BaseDelegator(delegator).setMaxL1Limit(middleware.BALANCER(), collateralClassId, amount);
     }
 
     function slashVault() external pure {

--- a/test/rewards/RewardsAssetsSharesTest.t.sol
+++ b/test/rewards/RewardsAssetsSharesTest.t.sol
@@ -134,18 +134,18 @@ contract RewardsAssetShareTest is Test {
         // Set vault delegation: 300 tokens staked to Operator A
         uint256 epochTs = middleware.getEpochStartTs(epoch);
         MockDelegator(delegator1).setStake(
-            middleware.L1_VALIDATOR_MANAGER(),
+            middleware.BALANCER(),
             1, // asset class
             OPERATOR_A,
             uint48(epochTs),
             300 // stake amount
         );
-        MockDelegator(delegator1).setStake(middleware.L1_VALIDATOR_MANAGER(), 1, OPERATOR_B, uint48(epochTs), 700);
+        MockDelegator(delegator1).setStake(middleware.BALANCER(), 1, OPERATOR_B, uint48(epochTs), 700);
         MockDelegator(delegator2).setStake(
-            middleware.L1_VALIDATOR_MANAGER(), 2, OPERATOR_B, uint48(epochTs), 100
+            middleware.BALANCER(), 2, OPERATOR_B, uint48(epochTs), 100
         );
         MockDelegator(delegator3).setStake(
-            middleware.L1_VALIDATOR_MANAGER(), 3, OPERATOR_B, uint48(epochTs), 100
+            middleware.BALANCER(), 3, OPERATOR_B, uint48(epochTs), 100
         );
 
         // Set rewards for the epoch: 100,000 tokens
@@ -216,7 +216,7 @@ contract RewardsAssetShareTest is Test {
         (address vault, address delegator) = vaultManager.deployAndAddVault(address(0x123), address(0x500));
         vaultManager.setVaultCollateralClass(vault, 1);
         uint256 epochTs = middleware.getEpochStartTs(epoch);
-        MockDelegator(delegator).setStake(middleware.L1_VALIDATOR_MANAGER(), 1, OPERATOR_A, uint48(epochTs), 100);
+        MockDelegator(delegator).setStake(middleware.BALANCER(), 1, OPERATOR_A, uint48(epochTs), 100);
 
         // Set rewards for the epoch
         vm.prank(REWARDS_DISTRIBUTOR);

--- a/test/rewards/RewardsIntegrationTest.t.sol
+++ b/test/rewards/RewardsIntegrationTest.t.sol
@@ -17,8 +17,6 @@ import {IMiddlewareVaultManager} from "../../src/interfaces/middleware/IMiddlewa
 
 contract RewardsIntegrationTest is MiddlewareTestBase {
     /* ─── Test Actors ─────────────────────────────────────────────────────── */
-    address internal admin;
-    address internal protocolOwner;
     address internal rewardsManager;
     address internal rewardsDistributor;
 
@@ -50,8 +48,7 @@ contract RewardsIntegrationTest is MiddlewareTestBase {
         }
 
         // Initialize test actors with descriptive labels
-        admin = makeAddr("admin");
-        protocolOwner = makeAddr("protocolOwner");
+        // protocolOwner and l1Owner are inherited from MiddlewareTestBase
         rewardsManager = makeAddr("rewardsManager");
         rewardsDistributor = makeAddr("rewardsDistributor");
 
@@ -59,7 +56,7 @@ contract RewardsIntegrationTest is MiddlewareTestBase {
 
         rewards = new Rewards();
         rewards.initialize(
-            admin,
+            l1Owner,  // Rewards should be owned by l1Owner according to the new ownership model
             protocolOwner,
             payable(address(middleware)),             // real middleware
             address(uptime),
@@ -69,7 +66,7 @@ contract RewardsIntegrationTest is MiddlewareTestBase {
             11_520 // minRequiredUptime (3.2 h)
         );
 
-        vm.prank(admin);
+        vm.prank(l1Owner);
         rewards.setRewardsManagerRole(rewardsManager);
         vm.prank(rewardsManager);
         rewards.setRewardsDistributorRole(rewardsDistributor);
@@ -118,7 +115,7 @@ contract RewardsIntegrationTest is MiddlewareTestBase {
         uint96[] memory ids = middleware.getCollateralClassIds();
         for (uint256 i = 0; i < ids.length; ++i) {
             if (ids[i] != 1) {                         // 1 = primary, already done above
-                vm.startPrank(validatorManagerAddress);
+                vm.startPrank(balancer);
                 try middleware.calcAndCacheStakes(epoch, ids[i]) {} catch {}
                 vm.stopPrank();
             }
@@ -648,7 +645,7 @@ contract RewardsIntegrationTest is MiddlewareTestBase {
     /* ─── ROLE TESTS -------------------------------------------------- */
     
     function test_ChangeAdminRole() public {
-        vm.startPrank(admin);
+        vm.startPrank(l1Owner);
 
         // Check current admin
         assertEq(rewards.hasRole(rewards.REWARDS_MANAGER_ROLE(), rewardsManager), true);
@@ -690,7 +687,7 @@ contract RewardsIntegrationTest is MiddlewareTestBase {
     }
 
     function test_ChangeProtocolOwner() public {
-        vm.startPrank(admin);
+        vm.startPrank(l1Owner);
 
         // Check current protocol owner
         assertEq(rewards.hasRole(rewards.PROTOCOL_OWNER_ROLE(), protocolOwner), true);
@@ -1031,7 +1028,7 @@ contract RewardsIntegrationTest is MiddlewareTestBase {
         uint96 newCollateralClass = 4;
         
         // Note: In real integration test, we need to add the asset class properly through middleware
-        vm.startPrank(validatorManagerAddress);
+        vm.startPrank(balancer);
         // We would need to add asset class through proper middleware methods
         // For now, we'll just adjust the rewards share
         vm.stopPrank();
@@ -1142,7 +1139,7 @@ contract RewardsIntegrationTest is MiddlewareTestBase {
         uint256 remainingOperators = operators.length;
         _warpToEpoch(epoch + 3);
         _syncStakeCache(epoch + 3);
-        vm.prank(validatorManagerAddress);
+        vm.prank(balancer);
         middleware.calcAndCacheNodeStakeForAllOperators();
         while (remainingOperators > 0) {
             vm.prank(rewardsDistributor);
@@ -1225,7 +1222,7 @@ contract RewardsIntegrationTest is MiddlewareTestBase {
         // Earliest legal distribution moment is epoch + DISTRIBUTION_EARLIEST_OFFSET
         _warpToEpoch(epoch + rewards.DISTRIBUTION_EARLIEST_OFFSET() + 1);
         _syncStakeCache(epoch + rewards.DISTRIBUTION_EARLIEST_OFFSET() + 1);
-        vm.prank(validatorManagerAddress);
+        vm.prank(balancer);
         middleware.calcAndCacheNodeStakeForAllOperators();
         vm.prank(rewardsDistributor);
         rewards.distributeRewards(epoch, 10);
@@ -1243,7 +1240,7 @@ contract RewardsIntegrationTest is MiddlewareTestBase {
         // Try to distribute before DISTRIBUTION_EARLIEST_OFFSET
         _warpToEpoch(epoch + 1);
         _syncStakeCache(epoch + 1);
-        vm.prank(validatorManagerAddress);
+        vm.prank(balancer);
         middleware.calcAndCacheNodeStakeForAllOperators();
         vm.prank(rewardsDistributor);
         vm.expectRevert(
@@ -1260,7 +1257,7 @@ contract RewardsIntegrationTest is MiddlewareTestBase {
         _warpToEpoch(epoch + rewards.DISTRIBUTION_EARLIEST_OFFSET() + 1);
         _syncStakeCache(epoch + rewards.DISTRIBUTION_EARLIEST_OFFSET() + 1);
 
-        vm.prank(validatorManagerAddress);
+        vm.prank(balancer);
         middleware.calcAndCacheNodeStakeForAllOperators();
         vm.prank(rewardsDistributor);
         vm.expectRevert(abi.encodeWithSelector(IRewards.EpochNotFunded.selector, epoch));
@@ -1280,7 +1277,7 @@ contract RewardsIntegrationTest is MiddlewareTestBase {
         _syncStakeCache(1 + rewards.FUNDING_DEADLINE_OFFSET() + 3);
 
         // Sequential requirement: distribute epoch 1 first, then epoch 2
-        vm.prank(validatorManagerAddress);
+        vm.prank(balancer);
         middleware.calcAndCacheNodeStakeForAllOperators();
         vm.prank(rewardsDistributor);
         rewards.distributeRewards(1, 10);
@@ -1323,7 +1320,7 @@ contract RewardsIntegrationTest is MiddlewareTestBase {
         
         _warpToEpoch(1 + rewards.DISTRIBUTION_EARLIEST_OFFSET() + 1);
         _syncStakeCache(1 + rewards.DISTRIBUTION_EARLIEST_OFFSET() + 1);
-        vm.prank(validatorManagerAddress);
+        vm.prank(balancer);
         middleware.calcAndCacheNodeStakeForAllOperators();
         vm.prank(rewardsDistributor);
         rewards.distributeRewards(1, 10);
@@ -1443,7 +1440,7 @@ contract RewardsIntegrationTest is MiddlewareTestBase {
         // Close funding window and distribute epoch 1 completely
         _warpToEpoch(1 + rewards.FUNDING_DEADLINE_OFFSET() + 3);
         _syncStakeCache(1 + rewards.FUNDING_DEADLINE_OFFSET() + 3);
-        vm.prank(validatorManagerAddress);
+        vm.prank(balancer);
         middleware.calcAndCacheNodeStakeForAllOperators();
         vm.prank(rewardsDistributor);
         rewards.distributeRewards(1, 10);
@@ -1579,7 +1576,7 @@ contract RewardsIntegrationTest is MiddlewareTestBase {
             
             // Only remove asset if this was the last active vault using it in this class
             if (isLastVaultUsingAsset) {
-                vm.prank(validatorManagerAddress);
+                vm.prank(l1Owner);
                 middleware.removeAssetFromClass(collateralClass, assetToCheck);
             }
         }
@@ -1614,7 +1611,7 @@ contract RewardsIntegrationTest is MiddlewareTestBase {
         _syncStakeCache(epoch + offset);
 
         // Off‑by‑one fixed: call should now succeed.
-        vm.prank(validatorManagerAddress);
+        vm.prank(balancer);
         middleware.calcAndCacheNodeStakeForAllOperators();
         vm.prank(rewardsDistributor);
         rewards.distributeRewards(epoch, 10);
@@ -1626,7 +1623,7 @@ contract RewardsIntegrationTest is MiddlewareTestBase {
         // ‑‑ remove every operator so getAllOperators() returns 0
         address[] memory ops = middleware.getAllOperators();
         for (uint256 i; i < ops.length; ++i) {
-            vm.prank(validatorManagerAddress);
+            vm.prank(l1Owner);
             middleware.disableOperator(ops[i]);
         }
 
@@ -1635,7 +1632,7 @@ contract RewardsIntegrationTest is MiddlewareTestBase {
         _warpToEpoch(targetEpoch);
         _syncStakeCache(targetEpoch);
         for (uint256 i; i < ops.length; ++i) {
-            vm.prank(validatorManagerAddress);
+            vm.prank(l1Owner);
             middleware.removeOperator(ops[i]);
         }
 
@@ -1695,14 +1692,14 @@ contract RewardsIntegrationTest is MiddlewareTestBase {
         // warp to update window and force update nodes to reflect stake changes
         uint256 updateWindowStart = middleware.getEpochStartTs(epoch) + middleware.UPDATE_WINDOW() + 1;
         vm.warp(updateWindowStart);
-        vm.prank(validatorManagerAddress);
+        vm.prank(l1Owner);
         middleware.forceUpdateNodes(op, 0);
 
         // Move to next epoch to process node removals
         _moveToNextEpochAndCalc(1);
         
         // refresh caches to reflect stake = 0
-        vm.prank(validatorManagerAddress);
+        vm.prank(balancer);
         middleware.calcAndCacheNodeStakeForAllOperators();
 
         // fund & distribute the epoch
@@ -1745,14 +1742,14 @@ contract RewardsIntegrationTest is MiddlewareTestBase {
         // warp to update window and force update nodes for all operators to reflect stake changes
         uint256 updateWindowStart = middleware.getEpochStartTs(epoch) + middleware.UPDATE_WINDOW() + 1;
         vm.warp(updateWindowStart);
-        vm.prank(validatorManagerAddress);
+        vm.prank(l1Owner);
         for (uint256 i; i < ops.length; ++i) {
             middleware.forceUpdateNodes(ops[i], 0);
         }
         
         // after you zero-stake, move one epoch forward so the removal is effective
         _moveToNextEpochAndCalc(1);
-        vm.prank(validatorManagerAddress);
+        vm.prank(balancer);
         middleware.calcAndCacheNodeStakeForAllOperators();
 
         /* ── 1. fund & finish epoch-1 ─────────────────────────────────────────── */
@@ -1816,14 +1813,14 @@ contract RewardsIntegrationTest is MiddlewareTestBase {
         // warp to update window and force update nodes for all operators to reflect stake changes
         uint256 updateWindowStart = middleware.getEpochStartTs(epoch) + middleware.UPDATE_WINDOW() + 1;
         vm.warp(updateWindowStart);
-        vm.prank(validatorManagerAddress);
+        vm.prank(l1Owner);
         for (uint256 i; i < ops.length; ++i) {
             middleware.forceUpdateNodes(ops[i], 0);
         }
         
         // after you zero-stake, move one epoch forward so the removal is effective
         _moveToNextEpochAndCalc(1);
-        vm.prank(validatorManagerAddress);
+        vm.prank(balancer);
         middleware.calcAndCacheNodeStakeForAllOperators();
 
         /* ── 1. fund & finish epoch-1 ─────────────────────────────────────────── */

--- a/test/rewards/RewardsIntegrationTest.t.sol
+++ b/test/rewards/RewardsIntegrationTest.t.sol
@@ -115,9 +115,7 @@ contract RewardsIntegrationTest is MiddlewareTestBase {
         uint96[] memory ids = middleware.getCollateralClassIds();
         for (uint256 i = 0; i < ids.length; ++i) {
             if (ids[i] != 1) {                         // 1 = primary, already done above
-                vm.startPrank(balancer);
                 try middleware.calcAndCacheStakes(epoch, ids[i]) {} catch {}
-                vm.stopPrank();
             }
         }
 
@@ -1028,10 +1026,8 @@ contract RewardsIntegrationTest is MiddlewareTestBase {
         uint96 newCollateralClass = 4;
         
         // Note: In real integration test, we need to add the asset class properly through middleware
-        vm.startPrank(balancer);
         // We would need to add asset class through proper middleware methods
         // For now, we'll just adjust the rewards share
-        vm.stopPrank();
         
         // Re‑balance so that the overall sum stays 100 %
         vm.startPrank(rewardsManager);
@@ -1139,7 +1135,6 @@ contract RewardsIntegrationTest is MiddlewareTestBase {
         uint256 remainingOperators = operators.length;
         _warpToEpoch(epoch + 3);
         _syncStakeCache(epoch + 3);
-        vm.prank(balancer);
         middleware.calcAndCacheNodeStakeForAllOperators();
         while (remainingOperators > 0) {
             vm.prank(rewardsDistributor);
@@ -1222,7 +1217,6 @@ contract RewardsIntegrationTest is MiddlewareTestBase {
         // Earliest legal distribution moment is epoch + DISTRIBUTION_EARLIEST_OFFSET
         _warpToEpoch(epoch + rewards.DISTRIBUTION_EARLIEST_OFFSET() + 1);
         _syncStakeCache(epoch + rewards.DISTRIBUTION_EARLIEST_OFFSET() + 1);
-        vm.prank(balancer);
         middleware.calcAndCacheNodeStakeForAllOperators();
         vm.prank(rewardsDistributor);
         rewards.distributeRewards(epoch, 10);
@@ -1240,7 +1234,6 @@ contract RewardsIntegrationTest is MiddlewareTestBase {
         // Try to distribute before DISTRIBUTION_EARLIEST_OFFSET
         _warpToEpoch(epoch + 1);
         _syncStakeCache(epoch + 1);
-        vm.prank(balancer);
         middleware.calcAndCacheNodeStakeForAllOperators();
         vm.prank(rewardsDistributor);
         vm.expectRevert(
@@ -1257,7 +1250,6 @@ contract RewardsIntegrationTest is MiddlewareTestBase {
         _warpToEpoch(epoch + rewards.DISTRIBUTION_EARLIEST_OFFSET() + 1);
         _syncStakeCache(epoch + rewards.DISTRIBUTION_EARLIEST_OFFSET() + 1);
 
-        vm.prank(balancer);
         middleware.calcAndCacheNodeStakeForAllOperators();
         vm.prank(rewardsDistributor);
         vm.expectRevert(abi.encodeWithSelector(IRewards.EpochNotFunded.selector, epoch));
@@ -1277,7 +1269,6 @@ contract RewardsIntegrationTest is MiddlewareTestBase {
         _syncStakeCache(1 + rewards.FUNDING_DEADLINE_OFFSET() + 3);
 
         // Sequential requirement: distribute epoch 1 first, then epoch 2
-        vm.prank(balancer);
         middleware.calcAndCacheNodeStakeForAllOperators();
         vm.prank(rewardsDistributor);
         rewards.distributeRewards(1, 10);
@@ -1320,7 +1311,6 @@ contract RewardsIntegrationTest is MiddlewareTestBase {
         
         _warpToEpoch(1 + rewards.DISTRIBUTION_EARLIEST_OFFSET() + 1);
         _syncStakeCache(1 + rewards.DISTRIBUTION_EARLIEST_OFFSET() + 1);
-        vm.prank(balancer);
         middleware.calcAndCacheNodeStakeForAllOperators();
         vm.prank(rewardsDistributor);
         rewards.distributeRewards(1, 10);
@@ -1440,7 +1430,6 @@ contract RewardsIntegrationTest is MiddlewareTestBase {
         // Close funding window and distribute epoch 1 completely
         _warpToEpoch(1 + rewards.FUNDING_DEADLINE_OFFSET() + 3);
         _syncStakeCache(1 + rewards.FUNDING_DEADLINE_OFFSET() + 3);
-        vm.prank(balancer);
         middleware.calcAndCacheNodeStakeForAllOperators();
         vm.prank(rewardsDistributor);
         rewards.distributeRewards(1, 10);
@@ -1611,7 +1600,6 @@ contract RewardsIntegrationTest is MiddlewareTestBase {
         _syncStakeCache(epoch + offset);
 
         // Off‑by‑one fixed: call should now succeed.
-        vm.prank(balancer);
         middleware.calcAndCacheNodeStakeForAllOperators();
         vm.prank(rewardsDistributor);
         rewards.distributeRewards(epoch, 10);
@@ -1699,7 +1687,6 @@ contract RewardsIntegrationTest is MiddlewareTestBase {
         _moveToNextEpochAndCalc(1);
         
         // refresh caches to reflect stake = 0
-        vm.prank(balancer);
         middleware.calcAndCacheNodeStakeForAllOperators();
 
         // fund & distribute the epoch
@@ -1749,7 +1736,6 @@ contract RewardsIntegrationTest is MiddlewareTestBase {
         
         // after you zero-stake, move one epoch forward so the removal is effective
         _moveToNextEpochAndCalc(1);
-        vm.prank(balancer);
         middleware.calcAndCacheNodeStakeForAllOperators();
 
         /* ── 1. fund & finish epoch-1 ─────────────────────────────────────────── */
@@ -1820,7 +1806,6 @@ contract RewardsIntegrationTest is MiddlewareTestBase {
         
         // after you zero-stake, move one epoch forward so the removal is effective
         _moveToNextEpochAndCalc(1);
-        vm.prank(balancer);
         middleware.calcAndCacheNodeStakeForAllOperators();
 
         /* ── 1. fund & finish epoch-1 ─────────────────────────────────────────── */

--- a/test/rewards/RewardsTest.t.sol
+++ b/test/rewards/RewardsTest.t.sol
@@ -367,7 +367,7 @@ contract RewardsTest is Test {
             // Set vault delegations proportional to operator's stake
             for (uint256 j = 0; j < delegators.length; j++) {
                 delegators[j].setStake(
-                    middleware.L1_VALIDATOR_MANAGER(),
+                    middleware.BALANCER(),
                     uint96(j + 1), // asset class
                     operator,
                     uint48(timestamp),
@@ -512,7 +512,7 @@ contract RewardsTest is Test {
             // Set vault delegations
             for (uint256 j = 0; j < delegators.length; j++) {
                 delegators[j].setStake(
-                    middleware.L1_VALIDATOR_MANAGER(), uint96(j + 1), operator, uint48(timestamp), operatorStake
+                    middleware.BALANCER(), uint96(j + 1), operator, uint48(timestamp), operatorStake
                 );
             }
 
@@ -598,7 +598,7 @@ contract RewardsTest is Test {
     ) internal {
         for (uint256 j = 0; j < delegators.length; j++) {
             delegators[j].setStake(
-            middleware.L1_VALIDATOR_MANAGER(),
+            middleware.BALANCER(),
             uint96(j + 1),
             operator,
             uint48(timestamp),


### PR DESCRIPTION
### Linked issues

<!-- List of issues this PR fixes. E.g.

- Fixes #12
- Fixes #14

-->

### Dependencies

<!-- List of PR that need to be merged before this PR. E.g.

- https://github.com/AshAvalanche/ash-infra/pull/26
- https://github.com/AshAvalanche/ansible-avalanche-collection/pull/32

If empty, please remove the section title -->

### Changes

Modifies compelte functions to be permissionless. Instead uses messageIndex to check correctness. 

-->

### Breaking changes

<!-- List of breaking changes brought by the PR. Proposed format: "- _(scope)_ Description". E.g.

- _(node role)_ `avalanche_tracked_subnets` has been renamed to `avalanchego_track_subnets`

-->

### Additional comments

<!-- You can for example ask for feedback here or link to new issues deriving from the PR.
If empty, please remove the section title -->
